### PR TITLE
Feat: #2 - 이미지 세이프 서치 구현

### DIFF
--- a/src/main/java/com/example/nzgeneration/global/openai/OpenAIController.java
+++ b/src/main/java/com/example/nzgeneration/global/openai/OpenAIController.java
@@ -1,0 +1,24 @@
+package com.example.nzgeneration.global.openai;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OpenAIController {
+
+    private final OpenAIService openAIService;
+
+    @GetMapping("api/openai/image-safety")
+    public ResponseEntity<Boolean> checkImageSafety(@RequestParam String imageUrl)
+        throws JsonProcessingException {
+            Boolean result = openAIService.getImageDescription(imageUrl);
+            return ResponseEntity.ok(result);
+    }
+
+}

--- a/src/main/java/com/example/nzgeneration/global/openai/OpenAIService.java
+++ b/src/main/java/com/example/nzgeneration/global/openai/OpenAIService.java
@@ -1,0 +1,68 @@
+package com.example.nzgeneration.global.openai;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class OpenAIService {
+
+    private String apiUrl = "https://api.openai.com/v1/chat/completions";
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    RestClient restClient = RestClient.create();
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    public Boolean getImageDescription(String imageUrl) throws JsonProcessingException {
+
+        Map<String, Object> textContent = new HashMap<>();
+        textContent.put("type", "text");
+        textContent.put("text", "Does the image contain any explicit, violent, or sensitive content such as nudity, violence, or tobacco? Respond with 'TRUE' for no such content and suitable for public display, or 'FALSE' if any such content is present.");
+
+        Map<String, Object> imageContent = new HashMap<>();
+        imageContent.put("type", "image_url");
+        imageContent.put("image_url", Map.of("url", imageUrl));
+
+        List<Map<String, Object>> contents = new ArrayList<>();
+        contents.add(textContent);
+        contents.add(imageContent);
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("role", "user");
+        message.put("content", contents);
+
+        // Create the outer request structure
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", "gpt-4-turbo");
+        requestBody.put("messages", List.of(message));
+        requestBody.put("max_tokens", 300);
+
+        ResponseEntity<String> response = restClient.post()
+            .uri(apiUrl)
+            .contentType(APPLICATION_JSON)
+            .header("Authorization", "Bearer " + apiKey)
+            .body(requestBody)
+            .retrieve()
+            .toEntity(String.class);
+
+        JsonNode rootNode = objectMapper.readTree(response.getBody());
+        JsonNode contentNode = rootNode.path("choices").get(0).path("message").path("content");
+
+        return contentNode.textValue().equals("TRUE");
+    }
+}


### PR DESCRIPTION
## 요약

- OpenAI 컨트롤러 작성
- OpenAI 서비스 코드 작성
    - checkImageSafety코드 작성

## 상세 내용

- api는 테스트용으로 확인위해 구현했습니다.
- Boolean을 반환하고 검사에 통과했다면 True입니다.
- nft사진 생성이후 이 메소드를 통과하여 예외처리를 할 예정입니다.

- 스프링 Restclient를 이용했습니다.

body생성 부분
 ```java
Map<String, Object> textContent = new HashMap<>();
        textContent.put("type", "text");
        textContent.put("text", "Does the image contain any explicit, violent, or sensitive content such as nudity, violence, or tobacco? Respond with 'TRUE' for no such content and suitable for public display, or 'FALSE' if any such content is present.");

        Map<String, Object> imageContent = new HashMap<>();
        imageContent.put("type", "image_url");
        imageContent.put("image_url", Map.of("url", imageUrl));

        List<Map<String, Object>> contents = new ArrayList<>();
        contents.add(textContent);
        contents.add(imageContent);

        Map<String, Object> message = new HashMap<>();
        message.put("role", "user");
        message.put("content", contents);

        // Create the outer request structure
        Map<String, Object> requestBody = new HashMap<>();
        requestBody.put("model", "gpt-4-turbo");
        requestBody.put("messages", List.of(message));
        requestBody.put("max_tokens", 300);
```

```java

//post
ResponseEntity<String> response = restClient.post()
            .uri(apiUrl)
            .contentType(APPLICATION_JSON)
            .header("Authorization", "Bearer " + apiKey)
            .body(requestBody)
            .retrieve()
            .toEntity(String.class);
//응답으로부터 content만 분리
        JsonNode rootNode = objectMapper.readTree(response.getBody());
        JsonNode contentNode = rootNode.path("choices").get(0).path("message").path("content");

        return contentNode.textValue().equals("TRUE");
```
