### PR TITLE
Feat: #5 - nft이미지 생성 구현

### DIFF
--- a/src/main/java/com/example/nzgeneration/global/openai/OpenAIController.java
+++ b/src/main/java/com/example/nzgeneration/global/openai/OpenAIController.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,11 +16,18 @@ public class OpenAIController {
 
     private final OpenAIService openAIService;
 
-    @GetMapping("api/openai/image-safety")
+    @GetMapping("test/openai/image-safety")
     public ResponseEntity<Boolean> checkImageSafety(@RequestParam String imageUrl)
         throws JsonProcessingException {
-            Boolean result = openAIService.getImageDescription(imageUrl);
-            return ResponseEntity.ok(result);
+        Boolean result = openAIService.getImageDescription(imageUrl);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("test/openai/image")
+    public ResponseEntity<String> createImage(@RequestParam String gender, @RequestParam String action,
+        @RequestParam String animal) throws JsonProcessingException {
+        String result = openAIService.createImage(openAIService.buildPrompt(gender, action, animal));
+        return ResponseEntity.ok(result);
     }
 
 }


### PR DESCRIPTION
## 요약

- openAIService에 nft생성 함수 작성

## 상세 내용

- requestparam으로 인자를 받으면 String으로 합쳐 하나의 프롬프트 생성
- 이후 open ai에 전송후 사진을 url로 반환받음(60분간 유효)
- 때문에 s3에 업로드하는 코드까지 구현했습니당~
- 추후 nftService를 작성할 때 이미지세이프까지 적용하고 s3까지 한번에 업로드하는 로직으로 구현 예정!



