### PR TITLE
Feat: #1 애플로그인, 회원가입, 자동 로그인(토큰 refresh) 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,16 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2023.0.0")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -47,6 +57,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    //애플 인증 서버에 JSON Web Key(JWK)를 가져올 때 사용
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/nzgeneration/NzGenerationApplication.java
+++ b/src/main/java/com/example/nzgeneration/NzGenerationApplication.java
@@ -5,11 +5,13 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @OpenAPIDefinition(servers={
     @Server(url ="/", description = "Default Server URL")
 })
 @SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@EnableFeignClients
 public class NzGenerationApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/nzgeneration/NzGenerationApplication.java
+++ b/src/main/java/com/example/nzgeneration/NzGenerationApplication.java
@@ -6,12 +6,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @OpenAPIDefinition(servers={
     @Server(url ="/", description = "Default Server URL")
 })
 @SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 @EnableFeignClients
+@EnableJpaAuditing
 public class NzGenerationApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
@@ -1,0 +1,16 @@
+package com.example.nzgeneration.domain.auth;
+
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCPublicKeysResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "AppleOAuthClient", url = "https://appleid.apple.com", configuration = AppleAuthApiClient.class)
+public interface AppleAuthApiClient {
+
+    @GetMapping("/auth/keys")
+    OIDCPublicKeysResponse getAppleOIDCOpenKeys();
+
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
@@ -3,10 +3,9 @@ package com.example.nzgeneration.domain.auth;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCPublicKeysResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "AppleOAuthClient", url = "https://appleid.apple.com", configuration = AppleAuthApiClient.class)
+
+@FeignClient(name = "AppleOAuthClient", url = "https://appleid.apple.com")
 public interface AppleAuthApiClient {
 
     @GetMapping("/auth/keys")

--- a/src/main/java/com/example/nzgeneration/domain/auth/AppleOauthHelper.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AppleOauthHelper.java
@@ -1,0 +1,28 @@
+package com.example.nzgeneration.domain.auth;
+
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCPublicKeysResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCDecodePayload;
+
+@Component
+@RequiredArgsConstructor
+public class AppleOauthHelper {
+    private final AppleAuthApiClient appleAuthApiClient;
+    private final OauthOIDCHelper oauthOIDCHelper;
+
+    @Value("${social-login.provider.apple.client-id}")
+    private String aud;
+
+    @Value("${social-login.provider.apple.issuer}")
+    private String iss;
+
+    public OIDCDecodePayload getOIDCDecodePayload(String token){
+        OIDCPublicKeysResponse oidcPublicKeysResponse = appleAuthApiClient.getAppleOIDCOpenKeys();
+        return oauthOIDCHelper.getPayloadFromIdToken(
+            token, iss, aud, oidcPublicKeysResponse
+        );
+    }
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
@@ -1,0 +1,41 @@
+package com.example.nzgeneration.domain.auth;
+
+import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.LoginSimpleInfo;
+import com.example.nzgeneration.domain.auth.enums.ResponseType;
+import com.example.nzgeneration.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name="Auth", description = "인증(로그인, 회원가입) 관련")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인/회원가입 api", description = "code : Authorization code / 회원가입, 로그인 구분 없이 동일한 API 사용")
+    public ApiResponse<LoginSimpleInfo> login(@RequestParam String idToken){
+        LoginSimpleInfo loginSimpleInfo = authService.login(idToken);
+        if(loginSimpleInfo.getResponseType()== ResponseType.SIGN_IN){
+            return ApiResponse.onSuccess(loginSimpleInfo);
+        }
+        return ApiResponse.onFailure(4003, "추가 정보 입력이 필요합니다", loginSimpleInfo);
+    }
+
+    @PostMapping("/signup/extra")
+    @Operation(summary = "회원가입 추가 정보 입력 api")
+    public ApiResponse<LoginSimpleInfo> signUp(@RequestParam String token, @RequestBody CreateUserRequest createUserRequest){
+        return ApiResponse.onSuccess(authService.signUp(token, createUserRequest));
+    }
+
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
@@ -44,5 +44,10 @@ public class AuthController {
         return ApiResponse.onSuccess(authService.signUp(token, createUserRequest));
     }
 
+    @PostMapping("/refresh-token")
+    @Operation(summary = "access token, refresh token 재발급")
+    public ApiResponse<LoginSimpleInfo> refreshToken(@RequestParam String refreshToken){
+        return ApiResponse.onSuccess(authService.updateUserToken(refreshToken));
+    }
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,7 +24,10 @@ public class AuthController {
 
     @PostMapping("/login")
     @Operation(summary = "로그인/회원가입 api", description = "code : Authorization code / 회원가입, 로그인 구분 없이 동일한 API 사용")
-    public ApiResponse<LoginSimpleInfo> login(@RequestParam String idToken){
+    public ApiResponse<LoginSimpleInfo> login(@RequestHeader("Authorization") String idToken){
+        if (idToken != null && idToken.startsWith("Bearer ")) {
+            idToken = idToken.substring("Bearer ".length());
+        }
         LoginSimpleInfo loginSimpleInfo = authService.login(idToken);
         if(loginSimpleInfo.getResponseType()== ResponseType.SIGN_IN){
             return ApiResponse.onSuccess(loginSimpleInfo);
@@ -33,7 +37,10 @@ public class AuthController {
 
     @PostMapping("/signup/extra")
     @Operation(summary = "회원가입 추가 정보 입력 api")
-    public ApiResponse<LoginSimpleInfo> signUp(@RequestParam String token, @RequestBody CreateUserRequest createUserRequest){
+    public ApiResponse<LoginSimpleInfo> signUp(@RequestHeader("Authorization") String token, @RequestBody CreateUserRequest createUserRequest){
+        if (token != null && token.startsWith("Bearer ")) {
+            token = token.substring("Bearer ".length());
+        }
         return ApiResponse.onSuccess(authService.signUp(token, createUserRequest));
     }
 

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
@@ -1,0 +1,52 @@
+package com.example.nzgeneration.domain.auth;
+
+import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.LoginSimpleInfo;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCDecodePayload;
+import com.example.nzgeneration.domain.auth.enums.ResponseType;
+import com.example.nzgeneration.domain.user.User;
+import com.example.nzgeneration.domain.user.UserRepository;
+import com.example.nzgeneration.global.common.response.ApiResponse;
+import com.example.nzgeneration.global.security.JwtTokenProvider;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AppleOauthHelper appleOauthHelper;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    @Transactional
+    public LoginSimpleInfo login(String idToken){
+        OIDCDecodePayload oidcDecodePayload = appleOauthHelper.getOIDCDecodePayload(idToken);
+        String email = oidcDecodePayload.email();
+        Optional<User> optionalMember = userRepository.findByEmail(email);
+        String accessToken, refreshToken;
+        if(optionalMember.isPresent()){ //로그인 로직
+            accessToken = jwtTokenProvider.createAccessToken(optionalMember.get().getPayload());
+            refreshToken = jwtTokenProvider.createRefreshToken(optionalMember.get().getId());
+            return LoginSimpleInfo.toDTO(accessToken, refreshToken, ResponseType.SIGN_IN);
+        }
+        accessToken = jwtTokenProvider.generateTempToken(email);
+        return LoginSimpleInfo.toDTO(accessToken, null, ResponseType.SIGN_UP);
+
+    }
+
+    @Transactional
+    public LoginSimpleInfo signUp(String token, CreateUserRequest createUserRequest){
+        String email = jwtTokenProvider.validateTempTokenAndGetEmail(token);
+        User user = User.toEntity(createUserRequest.getNickName(), email,
+            createUserRequest.getProfileImgUrl(), createUserRequest.getWalletAddress(),
+            createUserRequest.isAllowAdInfo(), createUserRequest.isAllowLocationInfo());
+        userRepository.save(user);
+        String accessToken = jwtTokenProvider.createAccessToken(user.getPayload());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+        return LoginSimpleInfo.toDTO(accessToken, refreshToken, ResponseType.SIGN_IN);
+    }
+
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/auth/OauthOIDCHelper.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/OauthOIDCHelper.java
@@ -1,0 +1,35 @@
+package com.example.nzgeneration.domain.auth;
+
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCDecodePayload;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCPublicKey;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCPublicKeysResponse;
+import com.example.nzgeneration.global.security.JwtOIDCProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class OauthOIDCHelper {
+
+    private final JwtOIDCProvider jwtOIDCProvider;
+
+    //토큰에서 kid 가져온다 -> 가져온 kid는 공개키 결정에 사용
+    private String getKidFromUnsignedIdToken(String token, String iss, String aud){
+        return jwtOIDCProvider.getKidFromUnsignedTokenHeader(token, iss, aud);
+    }
+
+    public OIDCDecodePayload getPayloadFromIdToken(String token, String iss, String aud, OIDCPublicKeysResponse oidcPublicKeysResponse){
+        String kid = getKidFromUnsignedIdToken(token, iss, aud);
+
+        //같은 Kid인 공개키 불러와서 토큰 검증에 사용
+        OIDCPublicKey oidcPublicKey = oidcPublicKeysResponse.keys().stream()
+            .filter(o-> o.kid().equals(kid))
+            .findFirst()
+            .orElseThrow();
+
+        //검증 된 토큰에서 바디를 꺼내온다
+        return jwtOIDCProvider.getOIDCTokenBody(token, oidcPublicKey.n(), oidcPublicKey.e());
+    }
+
+}
+

--- a/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
@@ -1,0 +1,21 @@
+package com.example.nzgeneration.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateUserRequest {
+        private String nickName;
+        private String walletAddress;
+        private String profileImgUrl;
+        private boolean isAllowLocationInfo;
+        private boolean isAllowAdInfo;
+
+    }
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
@@ -13,8 +13,8 @@ public class AuthRequestDto {
         private String nickName;
         private String walletAddress;
         private String profileImgUrl;
-        private boolean isAllowLocationInfo;
-        private boolean isAllowAdInfo;
+        private Boolean isAllowLocationInfo;
+        private Boolean isAllowAdInfo;
 
     }
 

--- a/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthResponseDto.java
@@ -1,0 +1,59 @@
+package com.example.nzgeneration.domain.auth.dto;
+
+import com.example.nzgeneration.domain.auth.enums.ResponseType;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthResponseDto {
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class LoginSimpleInfo{
+        private String accessToken;
+        private String refreshToken;
+        private ResponseType responseType;
+
+        public static LoginSimpleInfo toDTO(String accessToken, String refreshToken, ResponseType responseType) {
+            return LoginSimpleInfo.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .responseType(responseType)
+                .build();
+
+        }
+
+    }
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record OIDCPublicKeysResponse(List<OIDCPublicKey> keys) {
+    }
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record OIDCPublicKey(
+       String kty,
+       String kid,
+       String use,
+       String alg,
+       String n,
+       String e
+    ) {
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record OIDCDecodePayload(
+        String issuer,
+        String audience,
+        String subject,
+        String email
+
+    ){
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/auth/enums/ResponseType.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/enums/ResponseType.java
@@ -1,0 +1,5 @@
+package com.example.nzgeneration.domain.auth.enums;
+
+public enum ResponseType {
+    SIGN_IN, SIGN_UP
+}

--- a/src/main/java/com/example/nzgeneration/domain/auth/enums/ResponseType.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/enums/ResponseType.java
@@ -1,5 +1,5 @@
 package com.example.nzgeneration.domain.auth.enums;
 
 public enum ResponseType {
-    SIGN_IN, SIGN_UP
+    SIGN_IN, SIGN_UP, TOKEN_REFRESH
 }

--- a/src/main/java/com/example/nzgeneration/domain/board/Board.java
+++ b/src/main/java/com/example/nzgeneration/domain/board/Board.java
@@ -2,7 +2,7 @@ package com.example.nzgeneration.domain.board;
 
 import com.example.nzgeneration.global.utils.BaseTimeEntity;
 import com.example.nzgeneration.domain.nft.Nft;
-import com.example.nzgeneration.domain.member.Member;
+import com.example.nzgeneration.domain.user.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -29,5 +29,5 @@ public class Board extends BaseTimeEntity {
     private Nft nft;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Member uploadMember;
+    private User uploadUser;
 }

--- a/src/main/java/com/example/nzgeneration/domain/errorreport/ErrorReport.java
+++ b/src/main/java/com/example/nzgeneration/domain/errorreport/ErrorReport.java
@@ -2,7 +2,7 @@ package com.example.nzgeneration.domain.errorreport;
 
 import com.example.nzgeneration.global.utils.BaseTimeEntity;
 import com.example.nzgeneration.domain.trashcan.Trashcan;
-import com.example.nzgeneration.domain.member.Member;
+import com.example.nzgeneration.domain.user.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,7 +23,7 @@ public class ErrorReport extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne
-    private Member errorReportMember;
+    private User errorReportUser;
 
     private String content;
 

--- a/src/main/java/com/example/nzgeneration/domain/member/MemberRepository.java
+++ b/src/main/java/com/example/nzgeneration/domain/member/MemberRepository.java
@@ -1,8 +1,0 @@
-package com.example.nzgeneration.domain.member;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface MemberRepository extends JpaRepository<Member, Long>
-{
-
-}

--- a/src/main/java/com/example/nzgeneration/domain/memberbadge/MemberBadge.java
+++ b/src/main/java/com/example/nzgeneration/domain/memberbadge/MemberBadge.java
@@ -1,7 +1,7 @@
 package com.example.nzgeneration.domain.memberbadge;
 
 import com.example.nzgeneration.domain.badge.Badge;
-import com.example.nzgeneration.domain.member.Member;
+import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -25,7 +25,7 @@ public class MemberBadge extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Badge badge;

--- a/src/main/java/com/example/nzgeneration/domain/membernft/MemberNft.java
+++ b/src/main/java/com/example/nzgeneration/domain/membernft/MemberNft.java
@@ -1,7 +1,7 @@
 package com.example.nzgeneration.domain.membernft;
 
 import com.example.nzgeneration.domain.nft.Nft;
-import com.example.nzgeneration.domain.member.Member;
+import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -25,7 +25,7 @@ public class MemberNft extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Nft nft;

--- a/src/main/java/com/example/nzgeneration/domain/nft/Nft.java
+++ b/src/main/java/com/example/nzgeneration/domain/nft/Nft.java
@@ -1,7 +1,7 @@
 package com.example.nzgeneration.domain.nft;
 
 import com.example.nzgeneration.global.utils.BaseTimeEntity;
-import com.example.nzgeneration.domain.member.Member;
+import com.example.nzgeneration.domain.user.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -24,7 +24,7 @@ public class Nft extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
+    private User user;
 
     private String imageUrl;
 }

--- a/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReport.java
+++ b/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReport.java
@@ -2,7 +2,7 @@ package com.example.nzgeneration.domain.trashcanreport;
 
 import com.example.nzgeneration.domain.trashcan.TrashCategory;
 import com.example.nzgeneration.global.utils.BaseTimeEntity;
-import com.example.nzgeneration.domain.member.Member;
+import com.example.nzgeneration.domain.user.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -27,7 +27,7 @@ public class TrashcanReport extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Member trashcanReportMember;
+    private User trashcanReportUser;
 
     @Enumerated(EnumType.STRING)
     private TrashCategory trashCategory;

--- a/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportController.java
+++ b/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportController.java
@@ -17,10 +17,10 @@ public class TrashcanReportController {
 
     @PostMapping("trashcan")
     public ApiResponse<String> addTrashcanReport(
-        @RequestBody AddTrashcanReportRequest addTrashcanReportRequest, @CurrentUser User user) {
+        @RequestBody AddTrashcanReportRequest addTrashcanReportRequest) {
         trashcanReportService.addTrashcanReport(addTrashcanReportRequest.getMapX(),
             addTrashcanReportRequest.getMapY(), addTrashcanReportRequest.getImageUrl(),
-            addTrashcanReportRequest.getTrashCategory(), user);
+            addTrashcanReportRequest.getTrashCategory());
         return ApiResponse.onSuccess("제보에 성공했습니다.");
     }
 }

--- a/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportController.java
+++ b/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportController.java
@@ -1,7 +1,9 @@
 package com.example.nzgeneration.domain.trashcanreport;
 
 import com.example.nzgeneration.domain.trashcanreport.dto.TrashcanReportRequestDto.AddTrashcanReportRequest;
+import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.global.common.response.ApiResponse;
+import com.example.nzgeneration.global.security.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,10 +17,10 @@ public class TrashcanReportController {
 
     @PostMapping("trashcan")
     public ApiResponse<String> addTrashcanReport(
-        @RequestBody AddTrashcanReportRequest addTrashcanReportRequest) {
+        @RequestBody AddTrashcanReportRequest addTrashcanReportRequest, @CurrentUser User user) {
         trashcanReportService.addTrashcanReport(addTrashcanReportRequest.getMapX(),
             addTrashcanReportRequest.getMapY(), addTrashcanReportRequest.getImageUrl(),
-            addTrashcanReportRequest.getTrashCategory());
+            addTrashcanReportRequest.getTrashCategory(), user);
         return ApiResponse.onSuccess("제보에 성공했습니다.");
     }
 }

--- a/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportService.java
+++ b/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportService.java
@@ -17,10 +17,8 @@ public class TrashcanReportService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void addTrashcanReport(int mapX, int mapY, String imageUrl, TrashCategory trashCategory) {
+    public void addTrashcanReport(int mapX, int mapY, String imageUrl, TrashCategory trashCategory, User user) {
 
-        User user = userRepository.findById(1L)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
 
         //TODO - 유저 중복 처리
         TrashcanReport trashcanReport = TrashcanReport.builder()

--- a/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportService.java
+++ b/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportService.java
@@ -17,8 +17,10 @@ public class TrashcanReportService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void addTrashcanReport(int mapX, int mapY, String imageUrl, TrashCategory trashCategory, User user) {
+    public void addTrashcanReport(int mapX, int mapY, String imageUrl, TrashCategory trashCategory) {
 
+        User user = userRepository.findById(1L)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
 
         //TODO - 유저 중복 처리
         TrashcanReport trashcanReport = TrashcanReport.builder()

--- a/src/main/java/com/example/nzgeneration/domain/user/AppleTokenParser.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/AppleTokenParser.java
@@ -1,0 +1,8 @@
+package com.example.nzgeneration.domain.user;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AppleTokenParser {
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/user/AppleTokenParser.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/AppleTokenParser.java
@@ -1,8 +1,0 @@
-package com.example.nzgeneration.domain.user;
-
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
-public class AppleTokenParser {
-
-}

--- a/src/main/java/com/example/nzgeneration/domain/user/User.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/User.java
@@ -34,14 +34,11 @@ public class User extends BaseTimeEntity {
 
     private String walletAddress;
 
-    @ColumnDefault("0")
-    private int badgeCount = 0;
+    private int badgeCount;
 
-    @ColumnDefault("0")
-    private int cumulativePoint = 0;
+    private int cumulativePoint;
 
-    @ColumnDefault("0")
-    private int currentPoint = 0;
+    private int currentPoint;
 
     @ColumnDefault("true")
     private boolean isAllowLocationInfo;
@@ -63,7 +60,7 @@ public class User extends BaseTimeEntity {
     }
 
     public String getPayload(){
-        return this.getId()+"nz";
+        return this.getId()+"+nz";
     }
 
     public static User toEntity(String email, CreateUserRequest createUserRequest){
@@ -74,6 +71,9 @@ public class User extends BaseTimeEntity {
             .walletAddress(createUserRequest.getWalletAddress())
             .isAllowAdNotification(createUserRequest.getIsAllowAdInfo())
             .isAllowLocationInfo(createUserRequest.getIsAllowLocationInfo())
+            .badgeCount(0)
+            .cumulativePoint(0)
+            .currentPoint(0)
             .build();
     }
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/User.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/User.java
@@ -1,7 +1,9 @@
 package com.example.nzgeneration.domain.user;
 
 
+import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
 import com.example.nzgeneration.global.utils.BaseTimeEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -41,8 +43,10 @@ public class User extends BaseTimeEntity {
     @ColumnDefault("0")
     private int currentPoint = 0;
 
+    @ColumnDefault("true")
     private boolean isAllowLocationInfo;
 
+    @ColumnDefault("true")
     private boolean isAllowAdNotification;
 
     public void stamp(int point) {
@@ -50,18 +54,26 @@ public class User extends BaseTimeEntity {
         this.currentPoint += point;
     }
 
+    private String accessToken;
+    private String refreshToken;
+
+    public void updateToken(String accessToken, String refreshToken){
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
     public String getPayload(){
         return this.getId()+"nz";
     }
 
-    public static User toEntity(String nickName, String email, String profileImageUrl, String walletAddress, boolean isAllowAdNotification, boolean isAllowLocationInfo){
+    public static User toEntity(String email, CreateUserRequest createUserRequest){
         return User.builder()
-            .nickname(nickName)
+            .nickname(createUserRequest.getNickName())
             .email(email)
-            .profileImageUrl(profileImageUrl)
-            .walletAddress(walletAddress)
-            .isAllowAdNotification(isAllowAdNotification)
-            .isAllowLocationInfo(isAllowLocationInfo)
+            .profileImageUrl(createUserRequest.getProfileImgUrl())
+            .walletAddress(createUserRequest.getWalletAddress())
+            .isAllowAdNotification(createUserRequest.getIsAllowAdInfo())
+            .isAllowLocationInfo(createUserRequest.getIsAllowLocationInfo())
             .build();
     }
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/User.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/User.java
@@ -1,4 +1,4 @@
-package com.example.nzgeneration.domain.member;
+package com.example.nzgeneration.domain.user;
 
 
 import com.example.nzgeneration.global.utils.BaseTimeEntity;
@@ -16,13 +16,15 @@ import org.hibernate.annotations.ColumnDefault;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-public class Member extends BaseTimeEntity {
+public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String nickname;
+
+    private String email;
 
     private String profileImageUrl;
 

--- a/src/main/java/com/example/nzgeneration/domain/user/User.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -20,6 +21,7 @@ public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
     private Long id;
 
     private String nickname;
@@ -39,8 +41,27 @@ public class User extends BaseTimeEntity {
     @ColumnDefault("0")
     private int currentPoint = 0;
 
+    private boolean isAllowLocationInfo;
+
+    private boolean isAllowAdNotification;
+
     public void stamp(int point) {
         this.cumulativePoint += point;
         this.currentPoint += point;
+    }
+
+    public String getPayload(){
+        return this.getId()+"nz";
+    }
+
+    public static User toEntity(String nickName, String email, String profileImageUrl, String walletAddress, boolean isAllowAdNotification, boolean isAllowLocationInfo){
+        return User.builder()
+            .nickname(nickName)
+            .email(email)
+            .profileImageUrl(profileImageUrl)
+            .walletAddress(walletAddress)
+            .isAllowAdNotification(isAllowAdNotification)
+            .isAllowLocationInfo(isAllowLocationInfo)
+            .build();
     }
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/UserController.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserController.java
@@ -1,0 +1,9 @@
+package com.example.nzgeneration.domain.user;
+
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/user/UserController.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserController.java
@@ -2,6 +2,7 @@ package com.example.nzgeneration.domain.user;
 
 
 import com.example.nzgeneration.global.common.response.ApiResponse;
+import com.example.nzgeneration.global.security.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,8 +13,8 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("member/stamp")
-    public ApiResponse<String> addStamp() {
-        userService.addStamp();
+    public ApiResponse<String> addStamp(@CurrentUser User user) {
+        userService.addStamp(user);
         return ApiResponse.onSuccess("스탬프 찍기 성공");
     }
 

--- a/src/main/java/com/example/nzgeneration/domain/user/UserRepository.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.example.nzgeneration.domain.user;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/user/UserRepository.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
-
+    Optional<User> findByRefreshToken(String token);
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/UserService.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserService.java
@@ -13,10 +13,10 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void addStamp() {
+    public void addStamp(User user) {
         //TODO - 현재 멤버 불러오기
-        User user = userRepository.findById(1L)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
+//        User user = userRepository.findById(1L)
+//            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
 
         //TODO - 포인트 상수, 기준 정하기
         user.stamp(20);

--- a/src/main/java/com/example/nzgeneration/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/nzgeneration/global/common/response/code/status/ErrorStatus.java
@@ -18,10 +18,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //멤버 관련
     _EMPTY_USER(HttpStatus.CONFLICT, 4001, "존재하지 않는 사용자입니다."),
+    _INVALID_USER(HttpStatus.CONFLICT, 4002, "유효하지 않은 사용자입니다."),
 
     //인증 관련
     _EMPTY_JWT(HttpStatus.UNAUTHORIZED, 4011, "JWT가 존재하지 않습니다."),
     _INVALID_JWT(HttpStatus.UNAUTHORIZED, 4012, "유효하지 않은 JWT입니다."),
+    _EXPIRED_JWT(HttpStatus.UNAUTHORIZED, 4014, "만료된 JWT입니다."),
 
     //S3 관련
     _FAULT_S3_KEY(HttpStatus.NOT_FOUND, 4021, "잘못된 S3 정보입니다."),

--- a/src/main/java/com/example/nzgeneration/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/nzgeneration/global/common/response/code/status/ErrorStatus.java
@@ -19,6 +19,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //멤버 관련
     _EMPTY_USER(HttpStatus.CONFLICT, 4001, "존재하지 않는 사용자입니다."),
     _INVALID_USER(HttpStatus.CONFLICT, 4002, "유효하지 않은 사용자입니다."),
+    _DUPLICATE_USER(HttpStatus.CONFLICT, 4003, "이미 존재하는 사용자입니다"),
 
     //인증 관련
     _EMPTY_JWT(HttpStatus.UNAUTHORIZED, 4011, "JWT가 존재하지 않습니다."),

--- a/src/main/java/com/example/nzgeneration/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/nzgeneration/global/config/SwaggerConfig.java
@@ -18,7 +18,7 @@ public class SwaggerConfig {
         return new OpenAPI()
             .components(new Components())
             .info(apiInfo())
-          //  .addSecurityItem(securityRequirement())
+            .addSecurityItem(securityRequirement())
             .components(components());
     }
 
@@ -38,7 +38,7 @@ public class SwaggerConfig {
                 .bearerFormat("JWT"));
     }
 
-//    private SecurityRequirement securityRequirement(){
-//        return new SecurityRequirement().addList(jwtSchemeName);
-//    }
+    private SecurityRequirement securityRequirement(){
+        return new SecurityRequirement().addList(jwtSchemeName);
+    }
 }

--- a/src/main/java/com/example/nzgeneration/global/security/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/example/nzgeneration/global/security/CurrentUserArgumentResolver.java
@@ -4,6 +4,8 @@ import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.domain.user.UserRepository;
 import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -36,22 +38,22 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
         throw new GeneralException(ErrorStatus._EMPTY_JWT);
     }
 
-//    public User loadUserFromToken(String token) {
-//        try {
-//            Claims claims = Jwts.parser().setSigningKey(jwtTokenProvider.getSecretKey())
-//                .parseClaimsJws(token).getBody();
-//
-//            String targetIndex = "+";
-//
-//            String targetSubject = claims.getSubject();
-//
-//            int index = targetSubject.indexOf(targetIndex);
-//            String userId = targetSubject.substring(0, index);
-//
-//            return userRepository.findById(Long.valueOf(userId))
-//                .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
-//        } catch (Exception ex) {
-//            throw new GeneralException(ErrorStatus._INVALID_JWT);
-//        }
-//    }
+    public User loadUserFromToken(String token) {
+        try {
+            Claims claims = Jwts.parser().setSigningKey(jwtTokenProvider.getSecretKey())
+                .parseClaimsJws(token).getBody();
+
+            String targetIndex = "+";
+
+            String targetSubject = claims.getSubject();
+
+            int index = targetSubject.indexOf(targetIndex);
+            String userId = targetSubject.substring(0, index);
+
+            return userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
+        } catch (Exception ex) {
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
+        }
+    }
 }

--- a/src/main/java/com/example/nzgeneration/global/security/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/example/nzgeneration/global/security/CurrentUserArgumentResolver.java
@@ -1,7 +1,7 @@
 package com.example.nzgeneration.global.security;
 
-import com.example.nzgeneration.domain.member.Member;
-import com.example.nzgeneration.domain.member.MemberRepository;
+import com.example.nzgeneration.domain.user.User;
+import com.example.nzgeneration.domain.user.UserRepository;
 import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +16,12 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    private final MemberRepository memberRepository;
+    private final UserRepository userRepository;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.getParameterAnnotation(CurrentUser.class) != null
-            && parameter.getParameterType().equals(Member.class);
+            && parameter.getParameterType().equals(User.class);
     }
 
     @Override

--- a/src/main/java/com/example/nzgeneration/global/security/JwtOIDCProvider.java
+++ b/src/main/java/com/example/nzgeneration/global/security/JwtOIDCProvider.java
@@ -1,0 +1,102 @@
+package com.example.nzgeneration.global.security;
+
+import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
+import com.example.nzgeneration.global.common.response.exception.GeneralException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.Jwts;
+import java.math.BigInteger;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCDecodePayload;
+
+@Component
+@Configuration
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class JwtOIDCProvider {
+
+
+    //idToken의 header와 payload 받아옴
+    private String getUnsignedToken(String token){
+        String[] splitToken = token.split("\\.");
+        if(splitToken.length!=3)
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
+        return splitToken[0] + "." + splitToken[1] + ".";
+    }
+
+
+    //인증되지 않은 IdToken에서 payload 받아오는 로직
+    private Jwt<Header, Claims> getTokenClaims(String token, String iss, String aud) {
+        try {
+            return Jwts.parserBuilder()
+                .requireAudience(aud)
+                .requireIssuer(iss)
+                .build()
+                .parseClaimsJwt(getUnsignedToken(token));
+        } catch (ExpiredJwtException e) { //파싱하면서 만료된 토큰인지 확인.
+            throw new GeneralException(ErrorStatus._EXPIRED_JWT);
+        } catch (Exception e) {
+            log.error(e.toString());
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
+        }
+    }
+
+    private final String KID = "kid";
+    public String getKidFromUnsignedTokenHeader(String token, String iss, String aud){
+        return (String) getTokenClaims(token, iss, aud).getHeader().get(KID);
+    }
+
+    //공개키로 토큰 검증
+    public Jws<Claims> getOIDCTokenJws(String token, String modulus, String exponent){
+        try{
+            return Jwts.parserBuilder()
+                .setSigningKey(getRSAPublicKey(modulus, exponent))
+                .build()
+                .parseClaimsJws(token);
+        } catch (ExpiredJwtException e){
+            throw new GeneralException(ErrorStatus._EXPIRED_JWT);
+        } catch (Exception e){
+            log.error(e.toString());
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
+        }
+    }
+
+    //OIDCDecodePayload를 가져옴. OIDC 스펙 -> 공통 사용
+    public OIDCDecodePayload getOIDCTokenBody(String token, String modulus, String exponent){
+        Claims body = getOIDCTokenJws(token, modulus, exponent).getBody();
+        return new OIDCDecodePayload(
+            body.getIssuer(),
+            body.getAudience(),
+            body.getSubject(),
+            body.get("email", String.class)
+        );
+    }
+
+    //n, e 값으로 RSA 퍼블릭 키 연산
+    private Key getRSAPublicKey(String modulus, String exponent)
+        throws NoSuchAlgorithmException, InvalidKeySpecException {
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        byte[] decodeN = Base64.getUrlDecoder().decode(modulus);
+        byte[] decodeE = Base64.getUrlDecoder().decode(exponent);
+        BigInteger n = new BigInteger(1, decodeN);
+        BigInteger e = new BigInteger(1, decodeE);
+
+        RSAPublicKeySpec keySpec = new RSAPublicKeySpec(n, e);
+        return keyFactory.generatePublic(keySpec);
+    }
+
+}

--- a/src/main/java/com/example/nzgeneration/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/nzgeneration/global/security/JwtTokenProvider.java
@@ -1,5 +1,151 @@
 package com.example.nzgeneration.global.security;
 
+import com.example.nzgeneration.domain.user.User;
+import com.example.nzgeneration.domain.user.UserRepository;
+import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
+import com.example.nzgeneration.global.common.response.exception.GeneralException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.util.Base64;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+@Component
+@Configuration
+@RequiredArgsConstructor
+@PropertySource("classpath:application-main.yml")
+@Service
+@Slf4j
 public class JwtTokenProvider {
+    @Value("${jwt.access-token.expire-length}")
+    private long accessTokenValidityInMilliseconds;
+    @Value("${jwt.refresh-token.expire-length}")
+    private long refreshTokenValidityInMillseconds;
+    @Value("${jwt.custom.secretKey}")
+    private String SECRET_KEY;
+
+
+    private SecretKey cachedSecretKey;
+    private final UserRepository userRepository;
+
+    private SecretKey _getSecretKey() {
+        String keyBase64Encoded = Base64.getEncoder().encodeToString(SECRET_KEY.getBytes());
+        return Keys.hmacShaKeyFor(keyBase64Encoded.getBytes());
+    }
+
+
+    // 시크릿 키를 반환하는 method
+    public SecretKey getSecretKey() {
+        if (cachedSecretKey == null)
+            cachedSecretKey = _getSecretKey();
+
+        return cachedSecretKey;
+    }
+
+    public String createAccessToken(String payload) {
+        return createToken(payload, accessTokenValidityInMilliseconds);
+    }
+
+    public String createRefreshToken(Long climberId) {
+        return createToken(climberId.toString(), refreshTokenValidityInMillseconds);
+    }
+
+    public String refreshAccessToken(String refreshToken) {
+        if (validateToken(refreshToken)) {
+            Long userId = Long.parseLong(getPayload(refreshToken));
+            User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_USER));
+            String payload = user.getPayload();
+            return createAccessToken(payload);
+
+        } else {
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
+        }
+    }
+
+
+
+    public String createToken(String payload, long expireLength){
+        Claims claims = Jwts.claims().setSubject(payload);
+        Date now = new Date();
+        long nowMillis = now.getTime();
+        long expireMillis = nowMillis + (expireLength * 1000); // expireLength를 초 단위로 받았다고 가정
+        Date validity = new Date(expireMillis);
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(validity)
+            .signWith(SignatureAlgorithm.HS256, getSecretKey())
+            .compact();
+    }
+
+    public String getPayload(String token){
+        try{
+            return Jwts.parser()
+                .setSigningKey(getSecretKey())
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+        }catch (ExpiredJwtException e){
+            return e.getClaims().getSubject();
+        }catch(JwtException e){
+            log.error(e.toString());
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
+        }
+    }
+    public boolean validateToken(String token) {
+        try {
+            Jws<Claims> claimsJws = Jwts.parser().setSigningKey(getSecretKey()).parseClaimsJws(token);
+            Date now = new Date();
+            long nowMillis = now.getTime();
+            if (claimsJws.getBody().getExpiration().before(new Date())) {
+                throw new GeneralException(ErrorStatus._EXPIRED_JWT);
+            }
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.error(e.toString());
+            throw new GeneralException(ErrorStatus._EXPIRED_JWT);
+        } catch (JwtException | IllegalArgumentException exception) {
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
+        }
+    }
+
+    //회원가입 추가 정보 입력 시 사용
+    public String generateTempToken(String email){
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+            .setSubject(email)
+            .setIssuedAt(new Date(now))
+            .setExpiration(new Date(now + 1000 * 60 * 60)) // 1시간 유효
+            .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+            .compact();
+    }
+
+    // 임시 토큰 검증 및 이메일 추출
+    public String validateTempTokenAndGetEmail(String token) {
+        try {
+            return Jwts.parser()
+                .setSigningKey(SECRET_KEY)
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new GeneralException(ErrorStatus._EXPIRED_JWT);
+        } catch (Exception e){
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+    }
 
 }

--- a/src/main/java/com/example/nzgeneration/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/nzgeneration/global/security/JwtTokenProvider.java
@@ -51,8 +51,8 @@ public class JwtTokenProvider {
         return createToken(payload, accessTokenValidityInMilliseconds);
     }
 
-    public String createRefreshToken(Long climberId) {
-        return createToken(climberId.toString(), refreshTokenValidityInMillseconds);
+    public String createRefreshToken(Long userId) {
+        return createToken(userId.toString(), refreshTokenValidityInMillseconds);
     }
 
     public String refreshAccessToken(String refreshToken) {


### PR DESCRIPTION
## 요약
- 애플 로그인 기능(OIDC), 회원가입, 토큰 refresh 로직을 구현하였습니다
- CurrentUser 어노테이션 적용 시 문제가 생기는데, 우선 프론트에 api를 넘겨주고 문제를 해결하는게 좋을 것 같아서 우선 올렸습니다!

## 상세 내용

- 회원가입 시 서버 측에서 발급한 임시 토큰(유효기간 10분)을 이용하여 추가 정보를 입력할 수 있게 구현하였습니다

## 테스트 확인 내용

- 애플에서 내려 받은 idToken으로 작동 테스트 완료 하였고, 중복 처리 등의 예외처리 로직도 추가하였습니다. 

## 질문 및 이외 사항

- OIDC 로직 덕분에 이번에도 코드가 제법 기네용 .. ^^ 로그인 로직은 클밋에 올렸던 부분과 거의 유사하므로 참고해주세욥
