### PR TITLE
Feat: #10 로그인 회원가입 request 방식 수정, User 관련 API 구현

### DIFF
--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.nzgeneration.domain.auth;
 
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
+import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.UserIdTokenRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.LoginSimpleInfo;
 import com.example.nzgeneration.domain.auth.enums.ResponseType;
 import com.example.nzgeneration.global.common.response.ApiResponse;
@@ -9,7 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,11 +24,8 @@ public class AuthController {
 
     @PostMapping("/login")
     @Operation(summary = "로그인/회원가입 api", description = "code : Authorization code / 회원가입, 로그인 구분 없이 동일한 API 사용")
-    public ApiResponse<LoginSimpleInfo> login(@RequestHeader("Authorization") String idToken){
-        if (idToken != null && idToken.startsWith("Bearer ")) {
-            idToken = idToken.substring("Bearer ".length());
-        }
-        LoginSimpleInfo loginSimpleInfo = authService.login(idToken);
+    public ApiResponse<LoginSimpleInfo> login(@RequestBody UserIdTokenRequest userTokenRequest){
+        LoginSimpleInfo loginSimpleInfo = authService.login(userTokenRequest.getIdToken());
         if(loginSimpleInfo.getResponseType()== ResponseType.SIGN_IN){
             return ApiResponse.onSuccess(loginSimpleInfo);
         }
@@ -37,11 +34,8 @@ public class AuthController {
 
     @PostMapping("/signup/extra")
     @Operation(summary = "회원가입 추가 정보 입력 api")
-    public ApiResponse<LoginSimpleInfo> signUp(@RequestHeader("Authorization") String token, @RequestBody CreateUserRequest createUserRequest){
-        if (token != null && token.startsWith("Bearer ")) {
-            token = token.substring("Bearer ".length());
-        }
-        return ApiResponse.onSuccess(authService.signUp(token, createUserRequest));
+    public ApiResponse<LoginSimpleInfo> signUp(@RequestBody CreateUserRequest createUserRequest){
+        return ApiResponse.onSuccess(authService.signUp(createUserRequest));
     }
 
     @PostMapping("/refresh-token")

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
@@ -39,15 +39,17 @@ public class AuthService {
     }
 
     @Transactional
-    public LoginSimpleInfo signUp(String token, CreateUserRequest createUserRequest){
-        String email = jwtTokenProvider.validateTempTokenAndGetEmail(token);
+    public LoginSimpleInfo signUp(CreateUserRequest createUserRequest){
+        String email = jwtTokenProvider.validateTempTokenAndGetEmail(createUserRequest.getToken());
         if(userRepository.findByEmail(email).isPresent())
             throw new GeneralException(ErrorStatus._DUPLICATE_USER);
         User user = User.toEntity(email, createUserRequest);
+        System.out.println("Saving user with badgeCount: " + user.getBadgeCount());
         userRepository.save(user);
         String accessToken = jwtTokenProvider.createAccessToken(user.getPayload());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
         user.updateToken(accessToken, refreshToken);
+        System.out.println("Saving user with badgeCount: " + user.getBadgeCount());
         return LoginSimpleInfo.toDTO(accessToken, refreshToken, ResponseType.SIGN_IN);
     }
 

--- a/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
@@ -10,6 +10,7 @@ public class AuthRequestDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CreateUserRequest {
+        private String token;
         private String nickName;
         private String walletAddress;
         private String profileImgUrl;
@@ -17,5 +18,15 @@ public class AuthRequestDto {
         private Boolean isAllowAdInfo;
 
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserIdTokenRequest{
+        private String idToken;
+
+    }
+
+
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/User.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/User.java
@@ -39,25 +39,24 @@ public class User extends BaseTimeEntity {
     private String walletAddress;
 
     @Getter
-    @Column(nullable = false, columnDefinition = "int default 0")
-    private int badgeCount;
+    private Integer badgeCount = 0;
 
     @ColumnDefault("0")
-    private int cumulativePoint;
+    private Integer cumulativePoint = 0;
 
     @Getter
     @ColumnDefault("0")
-    private int currentPoint;
+    private Integer currentPoint = 0;
 
     @Getter
     @ColumnDefault("0")
-    private int nftCount;
+    private Integer nftCount = 0;
 
     @ColumnDefault("true")
-    private boolean isAllowLocationInfo;
+    private Boolean isAllowLocationInfo;
 
     @ColumnDefault("true")
-    private boolean isAllowAdNotification;
+    private Boolean isAllowAdNotification;
 
     public void stamp(int point) {
         this.cumulativePoint += point;
@@ -89,7 +88,7 @@ public class User extends BaseTimeEntity {
     }
 
     public LocalDateTime getCreatedAt(){
-        return this.getCreatedAt();
+        return super.getCreatedAt();
     }
 
     public static User toEntity(String email, CreateUserRequest createUserRequest){

--- a/src/main/java/com/example/nzgeneration/domain/user/User.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/User.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,19 +27,31 @@ public class User extends BaseTimeEntity {
     @Getter
     private Long id;
 
+    @Getter
     private String nickname;
 
     private String email;
 
+    @Getter
     private String profileImageUrl;
 
+    @Getter
     private String walletAddress;
 
+    @Getter
+    @Column(nullable = false, columnDefinition = "int default 0")
     private int badgeCount;
 
+    @ColumnDefault("0")
     private int cumulativePoint;
 
+    @Getter
+    @ColumnDefault("0")
     private int currentPoint;
+
+    @Getter
+    @ColumnDefault("0")
+    private int nftCount;
 
     @ColumnDefault("true")
     private boolean isAllowLocationInfo;
@@ -59,8 +72,24 @@ public class User extends BaseTimeEntity {
         this.refreshToken = refreshToken;
     }
 
+    public void updateNickName(String nickname){
+        this.nickname = nickname;
+    }
+
+    public void updateWalletAddress(String walletAddress){
+        this.walletAddress = walletAddress;
+    }
+
+    public void updateProfileImg(String imgUrl){
+        this.profileImageUrl = imgUrl;
+    }
+
     public String getPayload(){
         return this.getId()+"+nz";
+    }
+
+    public LocalDateTime getCreatedAt(){
+        return this.getCreatedAt();
     }
 
     public static User toEntity(String email, CreateUserRequest createUserRequest){
@@ -74,6 +103,7 @@ public class User extends BaseTimeEntity {
             .badgeCount(0)
             .cumulativePoint(0)
             .currentPoint(0)
+            .nftCount(0)
             .build();
     }
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/User.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/User.java
@@ -20,35 +20,29 @@ import org.hibernate.annotations.ColumnDefault;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Getter
     private Long id;
 
-    @Getter
     private String nickname;
 
     private String email;
 
-    @Getter
     private String profileImageUrl;
 
-    @Getter
     private String walletAddress;
 
-    @Getter
     private Integer badgeCount = 0;
 
     @ColumnDefault("0")
     private Integer cumulativePoint = 0;
 
-    @Getter
     @ColumnDefault("0")
     private Integer currentPoint = 0;
 
-    @Getter
     @ColumnDefault("0")
     private Integer nftCount = 0;
 

--- a/src/main/java/com/example/nzgeneration/domain/user/UserController.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserController.java
@@ -1,21 +1,72 @@
 package com.example.nzgeneration.domain.user;
 
 
+import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserEditingPageDetailInfo;
+import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserMyPageDetailInfo;
+import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserSigningSimpleInfo;
 import com.example.nzgeneration.global.common.response.ApiResponse;
 import com.example.nzgeneration.global.security.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/user")
 public class UserController {
     private final UserService userService;
 
-    @PostMapping("member/stamp")
+    @PostMapping("/stamp")
     public ApiResponse<String> addStamp(@CurrentUser User user) {
         userService.addStamp(user);
         return ApiResponse.onSuccess("스탬프 찍기 성공");
     }
+    @GetMapping("/check-nickname/{nickName}")
+    @Operation(summary = "닉네임 중복 확인", description = "true : 사용가능한 닉네임, false : 사용 불가능한 닉네임")
+    public ApiResponse<Boolean> checkNickName(@PathVariable String nickName){
+        boolean status = userService.checkNickNameDuplicate(nickName);
+        return ApiResponse.onSuccess(status);
+    }
+    @PatchMapping("/nickname/{nickName}")
+    public ApiResponse<String> updateNickName(@CurrentUser User user, @PathVariable String nickName){
+        userService.updateNickName(user, nickName);
+        return ApiResponse.onSuccess("닉네임 수정 완료");
+
+    }
+    @PatchMapping("/wallet-address/{walletAddress}")
+    public ApiResponse<String> updateWalletAddress(@CurrentUser User user, @PathVariable String walletAddress){
+        userService.updateWalletAddress(user, walletAddress);
+        return ApiResponse.onSuccess("지갑 주소 수정 완료");
+    }
+    @PatchMapping("/profile-image")
+    public ApiResponse<String> updateProfileImg(@CurrentUser User user, @RequestPart MultipartFile image){
+        userService.updateUserProfileImage(user, image);
+        return ApiResponse.onSuccess("프로필 사진 수정 완료");
+    }
+    @GetMapping("/days-signing")
+    public ApiResponse<UserSigningSimpleInfo> getDaysSigning(@CurrentUser User user){
+        return ApiResponse.onSuccess(userService.getDaysSigning(user));
+    }
+
+    @GetMapping("/my-page")
+    public ApiResponse<UserMyPageDetailInfo> getMyPageInfo(@CurrentUser User user){
+        return ApiResponse.onSuccess(userService.getMyPageInfo(user));
+    }
+
+    @GetMapping("/edit-page")
+    public ApiResponse<UserEditingPageDetailInfo> getEditPage(@CurrentUser User user){
+        return ApiResponse.onSuccess(userService.getEditPageInfo(user));
+    }
+
+
+
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/UserRepository.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByRefreshToken(String token);
+    Optional<User> findByNickname(String name);
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/UserService.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserService.java
@@ -46,10 +46,12 @@ public class UserService {
         user.updateNickName(name);
     }
 
+    @Transactional
     public void updateWalletAddress(User user, String address){
         user.updateWalletAddress(address);
     }
 
+    @Transactional
     public void updateUserProfileImage(User user, MultipartFile image){
         String profileImgUrl = s3Service.uploadFile(image).getImgUrl();
         user.updateProfileImg(profileImgUrl);
@@ -58,7 +60,7 @@ public class UserService {
     public UserSigningSimpleInfo getDaysSigning(User user){
         LocalDateTime createdAt= user.getCreatedAt();
         LocalDateTime now = LocalDateTime.now();
-        long daysBetween = ChronoUnit.DAYS.between(createdAt, now);
+        long daysBetween = ChronoUnit.DAYS.between(createdAt, now)+1;
         return UserSigningSimpleInfo.toDTO(user, daysBetween);
     }
 
@@ -69,6 +71,7 @@ public class UserService {
     public UserEditingPageDetailInfo getEditPageInfo(User user){
         return UserEditingPageDetailInfo.toDTO(user);
     }
+
 
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/UserService.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserService.java
@@ -1,16 +1,24 @@
 package com.example.nzgeneration.domain.user;
 
+import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserEditingPageDetailInfo;
+import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserMyPageDetailInfo;
+import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserSigningSimpleInfo;
 import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
+import com.example.nzgeneration.global.s3.S3Service;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final S3Service s3Service;
 
     @Transactional
     public void addStamp(User user) {
@@ -21,4 +29,46 @@ public class UserService {
         //TODO - 포인트 상수, 기준 정하기
         user.stamp(20);
     }
+
+    @Transactional
+    public boolean checkNickNameDuplicate(String name){
+        if(userRepository.findByNickname(name).isPresent()){
+            return false;
+        }
+        return true;
+    }
+
+    @Transactional
+    public void updateNickName(User user, String name){
+        if(!checkNickNameDuplicate(name)){
+            throw new GeneralException(ErrorStatus._DUPLICATE_NICKNAME);
+        }
+        user.updateNickName(name);
+    }
+
+    public void updateWalletAddress(User user, String address){
+        user.updateWalletAddress(address);
+    }
+
+    public void updateUserProfileImage(User user, MultipartFile image){
+        String profileImgUrl = s3Service.uploadFile(image).getImgUrl();
+        user.updateProfileImg(profileImgUrl);
+    }
+
+    public UserSigningSimpleInfo getDaysSigning(User user){
+        LocalDateTime createdAt= user.getCreatedAt();
+        LocalDateTime now = LocalDateTime.now();
+        long daysBetween = ChronoUnit.DAYS.between(createdAt, now);
+        return UserSigningSimpleInfo.toDTO(user, daysBetween);
+    }
+
+    public UserMyPageDetailInfo getMyPageInfo(User user){
+        return UserMyPageDetailInfo.toDTO(user);
+    }
+
+    public UserEditingPageDetailInfo getEditPageInfo(User user){
+        return UserEditingPageDetailInfo.toDTO(user);
+    }
+
+
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/dto/UserResponseDto.java
@@ -1,0 +1,66 @@
+package com.example.nzgeneration.domain.user.dto;
+
+import com.example.nzgeneration.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserResponseDto {
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserSigningSimpleInfo{
+        private String nickName;
+        private long howManyDays;
+
+        public static UserSigningSimpleInfo toDTO(User user, long days){
+            return UserSigningSimpleInfo.builder()
+                .nickName(user.getNickname())
+                .howManyDays(days)
+                .build();
+
+        }
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserMyPageDetailInfo{
+        private String nickName;
+        private int currentPoint;
+        private int badgeCount;
+        private int nftCount;
+
+        public static UserMyPageDetailInfo toDTO(User user){
+            return UserMyPageDetailInfo.builder()
+                .nickName(user.getNickname())
+                .badgeCount(user.getBadgeCount())
+                .currentPoint(user.getCurrentPoint())
+                .nftCount(user.getNftCount())
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserEditingPageDetailInfo{
+        private String profileImgUrl;
+        private String nickName;
+        private String walletAddress;
+
+        public static UserEditingPageDetailInfo toDTO(User user){
+            return UserEditingPageDetailInfo.builder()
+                .profileImgUrl(user.getProfileImageUrl())
+                .nickName(user.getNickname())
+                .walletAddress(user.getWalletAddress())
+                .build();
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/dto/UserResponseDto.java
@@ -30,9 +30,9 @@ public class UserResponseDto {
     @NoArgsConstructor
     public static class UserMyPageDetailInfo{
         private String nickName;
-        private int currentPoint;
-        private int badgeCount;
-        private int nftCount;
+        private Integer currentPoint;
+        private Integer badgeCount;
+        private Integer nftCount;
 
         public static UserMyPageDetailInfo toDTO(User user){
             return UserMyPageDetailInfo.builder()

--- a/src/main/java/com/example/nzgeneration/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/nzgeneration/global/common/response/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_USER(HttpStatus.CONFLICT, 4001, "존재하지 않는 사용자입니다."),
     _INVALID_USER(HttpStatus.CONFLICT, 4002, "유효하지 않은 사용자입니다."),
     _DUPLICATE_USER(HttpStatus.CONFLICT, 4003, "이미 존재하는 사용자입니다"),
+    _DUPLICATE_NICKNAME(HttpStatus.CONFLICT, 4003, "이미 존재하는 닉네임입니다"),
 
     //인증 관련
     _EMPTY_JWT(HttpStatus.UNAUTHORIZED, 4011, "JWT가 존재하지 않습니다."),

--- a/src/main/java/com/example/nzgeneration/global/config/WebConfig.java
+++ b/src/main/java/com/example/nzgeneration/global/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.example.nzgeneration.global.config;
+
+import com.example.nzgeneration.global.security.CurrentUserArgumentResolver;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Autowired
+    private CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/example/nzgeneration/global/security/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/example/nzgeneration/global/security/CurrentUserArgumentResolver.java
@@ -8,12 +8,14 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @RequiredArgsConstructor
+@Component
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -33,7 +35,7 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
         String authorizationHeader = webRequest.getHeader("authorization");
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
             String token = authorizationHeader.substring(7); // "Bearer " 이후 문자열
-            //return loadUserFromToken(token);
+            return loadUserFromToken(token);
         }
         throw new GeneralException(ErrorStatus._EMPTY_JWT);
     }

--- a/src/main/java/com/example/nzgeneration/global/utils/BaseTimeEntity.java
+++ b/src/main/java/com/example/nzgeneration/global/utils/BaseTimeEntity.java
@@ -13,6 +13,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
+    @Getter
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -20,4 +21,5 @@ public class BaseTimeEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
 }


### PR DESCRIPTION
## 요약

- 프론트 요청으로 로그인/회원가입 토큰을 header로 받던 부분을 body로 받도록 변경하였습니다(서버측 access token만 header로 받도록 통일)
- 유저 관련 API들을 개발 하였습니다(마이페이지, 유저정보 CRUD)
- CurrentUser 어노테이션 동작을 위한 WebConfig 설정을 추가하였습니다
- User 엔티티 변수들을 Wrapper Class로 변경하였습니다. 문제의 원인을 알고싶다..

## 상세 내용

**구현한 유저 관련 API**

-  닉네임 중복 확인
-  닉네임 수정
-  지갑주소 수정
-  OO님, N일 째 환경 보호 중! (가입 한지 며칠 째인지 계산)
-  보유 포인트 조회
-  보유 뱃지, NFT 갯수 조회
-  프로필 사진 편집
-  회원 정보 조회하기
-  회원 정보 편집하기(조회 화면)

## 테스트 확인 내용



## 질문 및 이외 사항

