### PR TITLE
Feat : 프로메테우스 - 그라파나 연결 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     //security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    //모니터링
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     //oauth 2.0
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'

--- a/src/main/java/com/example/nzgeneration/NzGenerationApplication.java
+++ b/src/main/java/com/example/nzgeneration/NzGenerationApplication.java
@@ -4,14 +4,13 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @OpenAPIDefinition(servers={
     @Server(url ="/", description = "Default Server URL")
 })
-@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@SpringBootApplication
 @EnableFeignClients
 @EnableJpaAuditing
 public class NzGenerationApplication {

--- a/src/main/java/com/example/nzgeneration/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/nzgeneration/global/security/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.example.nzgeneration.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(request ->
+                request.requestMatchers("/api/**").permitAll()
+                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
+                    .anyRequest().permitAll()
+            )
+            .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,11 @@
 spring:
   application:
     name: nz-generation
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
+  endpoint:
+    prometheus:
+      enabled: true


### PR DESCRIPTION
## 요약

- 프로메테우스 - 그라파나 연결 설정

- 스프링 액추에이터로 메트릭 수집, 마이크로미터로 외부 시스템이 이해하도록 변환, 프로메테우스 포맷으로 노출
- 프로메테우스는 스프링 엔드포인트로부터 접속해 메트릭들을 pull받아옴
- 그라파나는 그것들을 시각화

## 상세 내용

먼저 라이브러리 2개가 추가 필요함

```
implementation 'org.springframework.boot:spring-boot-starter-actuator'
runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
```

2개 관계가 이해가 너무 안되서 많이 찾아봤는데 아래 설명으로 잘 이해됐으면 좋겠음~!

- **Spring Boot Actuator**
  - 스프링 앱의 다양한 메트릭을 수집하고, 로컬 엔드포인트(health등)을 통해 노출
  -  localhost:8080/actuator로 보면 사용가능한 엔드포인트들이 보임
  - localhost:8080/actuator/health를 들어가면 현재 서버 상태 보임
- **Micrometer**
  - Actuator가  수집한 메트릭을 가져와서 종합, 다양한 외부 모니터링 시스템과 통합할때 사용
  - localhost:8080/actuator/prometheus

로컬에서만 확인하는거면 액추에이터! 다른 시스템으로 전송할거면 마이크로미터도 사용해야함!

yml설정
```yml
spring:
  application:
    name: nz-generation
management:
  endpoints:
    web:
      exposure:
        include: health, info, metrics, prometheus
  endpoint:
    prometheus:
      enabled: true
```

## 테스트 확인 내용

도커 컴포즈로 로컬에서 스프링 - 프로메테우스 - 그라파나 동작 확인했습니다~!
현재 nxtcloud ec2에서 스프링만 돌리고 
이전 사용했던 nzgeneration에서 프로메테우스와 그라파나를 컨테이너로 작동시킬 예정입니다~!

## 질문 및 이외 사항

- closed #17 
