### PR TITLE
Refactor: login ResponseType 변경

### DIFF
--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
@@ -3,7 +3,7 @@ package com.example.nzgeneration.domain.auth;
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.UserIdTokenRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.LoginSimpleInfo;
-import com.example.nzgeneration.domain.auth.enums.ResponseType;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.TokenRefreshSimpleInfo;
 import com.example.nzgeneration.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,7 +26,7 @@ public class AuthController {
     @Operation(summary = "로그인/회원가입 api", description = "code : Authorization code / 회원가입, 로그인 구분 없이 동일한 API 사용")
     public ApiResponse<LoginSimpleInfo> login(@RequestBody UserIdTokenRequest userTokenRequest){
         LoginSimpleInfo loginSimpleInfo = authService.login(userTokenRequest.getIdToken());
-        if(loginSimpleInfo.getResponseType()== ResponseType.SIGN_IN){
+        if(loginSimpleInfo.getIsSignUp()){
             return ApiResponse.onSuccess(loginSimpleInfo);
         }
         return ApiResponse.onFailure(4003, "추가 정보 입력이 필요합니다", loginSimpleInfo);
@@ -40,7 +40,7 @@ public class AuthController {
 
     @PostMapping("/refresh-token")
     @Operation(summary = "access token, refresh token 재발급")
-    public ApiResponse<LoginSimpleInfo> refreshToken(@RequestParam String refreshToken){
+    public ApiResponse<TokenRefreshSimpleInfo> refreshToken(@RequestParam String refreshToken){
         return ApiResponse.onSuccess(authService.updateUserToken(refreshToken));
     }
 

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
@@ -3,10 +3,9 @@ package com.example.nzgeneration.domain.auth;
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.LoginSimpleInfo;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCDecodePayload;
-import com.example.nzgeneration.domain.auth.enums.ResponseType;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.TokenRefreshSimpleInfo;
 import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.domain.user.UserRepository;
-import com.example.nzgeneration.global.common.response.ApiResponse;
 import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
 import com.example.nzgeneration.global.security.JwtTokenProvider;
@@ -31,10 +30,10 @@ public class AuthService {
         if(optionalMember.isPresent()){ //로그인 로직
             accessToken = jwtTokenProvider.createAccessToken(optionalMember.get().getPayload());
             refreshToken = jwtTokenProvider.createRefreshToken(optionalMember.get().getId());
-            return LoginSimpleInfo.toDTO(accessToken, refreshToken, ResponseType.SIGN_IN);
+            return LoginSimpleInfo.toDTO(accessToken, refreshToken, true);
         }
         accessToken = jwtTokenProvider.generateTempToken(email);
-        return LoginSimpleInfo.toDTO(accessToken, null, ResponseType.SIGN_UP);
+        return LoginSimpleInfo.toDTO(accessToken, null, false);
 
     }
 
@@ -44,17 +43,15 @@ public class AuthService {
         if(userRepository.findByEmail(email).isPresent())
             throw new GeneralException(ErrorStatus._DUPLICATE_USER);
         User user = User.toEntity(email, createUserRequest);
-        System.out.println("Saving user with badgeCount: " + user.getBadgeCount());
         userRepository.save(user);
         String accessToken = jwtTokenProvider.createAccessToken(user.getPayload());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
         user.updateToken(accessToken, refreshToken);
-        System.out.println("Saving user with badgeCount: " + user.getBadgeCount());
-        return LoginSimpleInfo.toDTO(accessToken, refreshToken, ResponseType.SIGN_IN);
+        return LoginSimpleInfo.toDTO(accessToken, refreshToken, true);
     }
 
     @Transactional
-    public LoginSimpleInfo updateUserToken(String refreshToken) {
+    public TokenRefreshSimpleInfo updateUserToken(String refreshToken) {
         if(userRepository.findByRefreshToken(refreshToken).isEmpty()){
             throw new GeneralException(ErrorStatus._EXPIRED_JWT);
         }
@@ -64,7 +61,7 @@ public class AuthService {
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
         String newAccesstoken = jwtTokenProvider.refreshAccessToken(refreshToken);
         user.updateToken(newAccesstoken, newRefreshToken);
-        return new LoginSimpleInfo(newAccesstoken, newRefreshToken, ResponseType.TOKEN_REFRESH);
+        return TokenRefreshSimpleInfo.toDTO(newAccesstoken, newRefreshToken);
 
     }
 

--- a/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthResponseDto.java
@@ -1,6 +1,5 @@
 package com.example.nzgeneration.domain.auth.dto;
 
-import com.example.nzgeneration.domain.auth.enums.ResponseType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
@@ -17,14 +16,32 @@ public class AuthResponseDto {
     public static class LoginSimpleInfo{
         private String accessToken;
         private String refreshToken;
-        private ResponseType responseType;
+        private Boolean isSignUp;
 
-        public static LoginSimpleInfo toDTO(String accessToken, String refreshToken, ResponseType responseType) {
+        public static LoginSimpleInfo toDTO(String accessToken, String refreshToken, boolean isSignUp) {
             return LoginSimpleInfo.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
-                .responseType(responseType)
+                .isSignUp(isSignUp)
                 .build();
+
+        }
+
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TokenRefreshSimpleInfo{
+        private String accessToken;
+        private String refreshToken;
+
+        public static TokenRefreshSimpleInfo toDTO(String accessToken, String refreshToken) {
+            return TokenRefreshSimpleInfo.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
 
         }
 

--- a/src/main/java/com/example/nzgeneration/domain/auth/enums/ResponseType.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/enums/ResponseType.java
@@ -1,5 +1,0 @@
-package com.example.nzgeneration.domain.auth.enums;
-
-public enum ResponseType {
-    SIGN_IN, SIGN_UP, TOKEN_REFRESH
-}

--- a/src/main/java/com/example/nzgeneration/global/common/response/ApiResponse.java
+++ b/src/main/java/com/example/nzgeneration/global/common/response/ApiResponse.java
@@ -31,16 +31,6 @@ public class ApiResponse<T> {
         return new ApiResponse<>(false, code, message, data);
     }
 
-    // result 필드를 JSON 형식으로 변환하는 메소드
-    public String getResultAsJson() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            return objectMapper.writeValueAsString(this.result);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
 
 
 


### PR DESCRIPTION
## 요약
- iOS의 요청으로 로그인/회원가입 api에서 response 형태를 변경했습니다!

## 상세 내용
- 기존 ) Response를 로그인, 회원가입, 토큰 리프레시 동일하게 사용
- 변경 ) 로그인, 회원가입은 동일한 Response 사용, 토큰 리프레시 새로운 response로 수정

## 테스트 확인 내용



## 질문 및 이외 사항

