### PR TITLE
Feat : 랭킹 조회

### DIFF
--- a/src/main/java/com/example/nzgeneration/domain/user/User.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/User.java
@@ -3,7 +3,6 @@ package com.example.nzgeneration.domain.user;
 
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
 import com.example.nzgeneration.global.utils.BaseTimeEntity;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -51,6 +50,9 @@ public class User extends BaseTimeEntity {
 
     @ColumnDefault("true")
     private Boolean isAllowAdNotification;
+
+    @ColumnDefault("0")
+    private Long ranking;
 
     public void stamp(int point) {
         this.cumulativePoint += point;

--- a/src/main/java/com/example/nzgeneration/domain/user/UserController.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserController.java
@@ -62,7 +62,13 @@ public class UserController {
         return ApiResponse.onSuccess(userService.getEditPageInfo(user));
     }
 
-
-
+    @GetMapping("/ranking")
+    @Operation(
+        summary = "랭킹 조회",
+        description = "1위, 2위, 3위 정보와 내 순위 주변 정보를 나눴습니다"
+    )
+    public ApiResponse<Object> getRanking(@CurrentUser User user) {
+        return ApiResponse.onSuccess(userService.getRanking(user));
+    }
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/UserRepository.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserRepository.java
@@ -1,5 +1,7 @@
 package com.example.nzgeneration.domain.user;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +9,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByRefreshToken(String token);
     Optional<User> findByNickname(String name);
+
+    List<User> findTop3ByOrderByRankingAsc();
+
+    List<User> findUsersByRankingBetweenOrderByRankingAsc(Long start, Long end);
+
+    List<User> findUsersByRankingGreaterThanOrderByRankingAsc(Long ranking);
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/UserService.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserService.java
@@ -1,14 +1,18 @@
 package com.example.nzgeneration.domain.user;
 
 import com.example.nzgeneration.domain.auth.AuthService;
+import com.example.nzgeneration.domain.user.dto.UserResponseDto.RankingInfo;
 import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserEditingPageDetailInfo;
 import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserMyPageDetailInfo;
+import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserRankingInfo;
 import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserSigningSimpleInfo;
 import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
 import com.example.nzgeneration.global.s3.S3Service;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,39 +37,109 @@ public class UserService {
     }
 
     @Transactional
-    public void updateNickName(User user, String name){
-        if(!authService.checkNickNameDuplicate(name)){
+    public void updateNickName(User user, String name) {
+        if (!authService.checkNickNameDuplicate(name)) {
             throw new GeneralException(ErrorStatus._DUPLICATE_NICKNAME);
         }
         user.updateNickName(name);
     }
 
     @Transactional
-    public void updateWalletAddress(User user, String address){
+    public void updateWalletAddress(User user, String address) {
         user.updateWalletAddress(address);
     }
 
     @Transactional
-    public void updateUserProfileImage(User user, MultipartFile image){
+    public void updateUserProfileImage(User user, MultipartFile image) {
         String profileImgUrl = s3Service.uploadFile(image).getImgUrl();
         user.updateProfileImg(profileImgUrl);
     }
 
-    public UserSigningSimpleInfo getDaysSigning(User user){
-        LocalDateTime createdAt= user.getCreatedAt();
+    public UserSigningSimpleInfo getDaysSigning(User user) {
+        LocalDateTime createdAt = user.getCreatedAt();
         LocalDateTime now = LocalDateTime.now();
-        long daysBetween = ChronoUnit.DAYS.between(createdAt, now)+1;
+        long daysBetween = ChronoUnit.DAYS.between(createdAt, now) + 1;
         return UserSigningSimpleInfo.toDTO(user, daysBetween);
     }
 
-    public UserMyPageDetailInfo getMyPageInfo(User user){
+    public UserMyPageDetailInfo getMyPageInfo(User user) {
         return UserMyPageDetailInfo.toDTO(user);
     }
 
-    public UserEditingPageDetailInfo getEditPageInfo(User user){
+    public UserEditingPageDetailInfo getEditPageInfo(User user) {
         return UserEditingPageDetailInfo.toDTO(user);
     }
 
 
+    public RankingInfo getRanking(User user) {
+
+        Long userRanking = user.getRanking();
+
+        //상위 3명 가져오기
+        List<User> top3Users = userRepository.findTop3ByOrderByRankingAsc();
+
+        //하위 리스트
+        //만약 유저가 3위 이내라면 4위부터 6개를 가져온다
+        //아니라면 유저 순위 근처를 가져온다
+        List<User> surroundingRankings;
+        if (userRanking <= 3) {
+            surroundingRankings = userRepository.findUsersByRankingGreaterThanOrderByRankingAsc(userRanking).stream()
+                .limit(6)
+                .collect(Collectors.toList());
+        } else {
+            surroundingRankings = userRepository.findUsersByRankingBetweenOrderByRankingAsc(userRanking - 2, userRanking + 3);
+        }
+
+        //상위 3개 매핑
+        List<UserRankingInfo> top3RankingInfos = top3Users.stream()
+            .map(u -> UserRankingInfo.builder()
+                .rank(u.getRanking())
+                .profileImageUrl(u.getProfileImageUrl())
+                .nickname(u.getNickname())
+                .points(u.getCumulativePoint())
+                .isCurrentUser(u.getId().equals(user.getId()))
+                .build())
+            .collect(Collectors.toList());
+
+        //하위 리스트 매핑
+        List<UserRankingInfo> surroundingRankingInfos = surroundingRankings.stream()
+            .map(u -> UserRankingInfo.builder()
+                .rank(u.getRanking())
+                .profileImageUrl(u.getProfileImageUrl())
+                .nickname(u.getNickname())
+                .points(u.getCumulativePoint())
+                .isCurrentUser(u.getId().equals(user.getId()))
+                .build())
+            .collect(Collectors.toList());
+
+        //동일 순위 예외 처리
+        while (surroundingRankingInfos.size() > 6) {
+            surroundingRankingInfos.remove(surroundingRankingInfos.size() - 1);
+        }
+
+
+        UserRankingInfo firstRanker = null;
+        UserRankingInfo secondRanker = null;
+        UserRankingInfo thirdRanker = null;
+
+        if (top3RankingInfos.size() > 0) {
+            firstRanker = top3RankingInfos.get(0);
+        }
+
+        if (top3RankingInfos.size() > 1) {
+            secondRanker = top3RankingInfos.get(1);
+        }
+
+        if (top3RankingInfos.size() > 2) {
+            thirdRanker = top3RankingInfos.get(2);
+        }
+
+        return RankingInfo.builder()
+            .firstRanker(firstRanker)
+            .secondRanker(secondRanker)
+            .thirdRanker(thirdRanker)
+            .userRankingList(surroundingRankingInfos)
+            .build();
+    }
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/dto/UserResponseDto.java
@@ -1,21 +1,24 @@
 package com.example.nzgeneration.domain.user.dto;
 
 import com.example.nzgeneration.domain.user.User;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class UserResponseDto {
+
     @Builder
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class UserSigningSimpleInfo{
+    public static class UserSigningSimpleInfo {
+
         private String nickName;
         private long howManyDays;
 
-        public static UserSigningSimpleInfo toDTO(User user, long days){
+        public static UserSigningSimpleInfo toDTO(User user, long days) {
             return UserSigningSimpleInfo.builder()
                 .nickName(user.getNickname())
                 .howManyDays(days)
@@ -28,13 +31,14 @@ public class UserResponseDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class UserMyPageDetailInfo{
+    public static class UserMyPageDetailInfo {
+
         private String nickName;
         private Integer currentPoint;
         private Integer badgeCount;
         private Integer nftCount;
 
-        public static UserMyPageDetailInfo toDTO(User user){
+        public static UserMyPageDetailInfo toDTO(User user) {
             return UserMyPageDetailInfo.builder()
                 .nickName(user.getNickname())
                 .badgeCount(user.getBadgeCount())
@@ -48,12 +52,13 @@ public class UserResponseDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class UserEditingPageDetailInfo{
+    public static class UserEditingPageDetailInfo {
+
         private String profileImgUrl;
         private String nickName;
         private String walletAddress;
 
-        public static UserEditingPageDetailInfo toDTO(User user){
+        public static UserEditingPageDetailInfo toDTO(User user) {
             return UserEditingPageDetailInfo.builder()
                 .profileImgUrl(user.getProfileImageUrl())
                 .nickName(user.getNickname())
@@ -62,5 +67,41 @@ public class UserResponseDto {
         }
 
     }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RankingInfo {
+
+        private UserRankingInfo firstRanker;
+        private UserRankingInfo secondRanker;
+        private UserRankingInfo thirdRanker;
+        private List<UserRankingInfo> userRankingList;
+
+        public static RankingInfo toDTO(UserRankingInfo firstRanker, UserRankingInfo secondRanker,
+            UserRankingInfo thirdRanker, List<UserRankingInfo> userRankingList) {
+            return RankingInfo.builder()
+                .firstRanker(firstRanker)
+                .secondRanker(secondRanker)
+                .thirdRanker(thirdRanker)
+                .userRankingList(userRankingList)
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserRankingInfo {
+
+        private Long rank;
+        private String profileImageUrl;
+        private String nickname;
+        private int points;
+        private Boolean isCurrentUser;
+    }
+
 
 }


### PR DESCRIPTION
## 요약

- 랭킹 조회 api
- 랭킹 업데이트 람다

## 상세 내용

- 랭킹 조회
  - 피그마 보면 1,2,3위와 하위리스트로 구분되기에 dto도 구분했슴당
  - 기준이 없지만 제가 임의의 기준으로 나눴습니다
  - 만약 유저가 1, 2, 3위 내에 있다
    - 하위 리스트는 4위부터 쭉 조회
  - 만약 없다면?
    - 하위리스트는 유저 주변으로 조회
- 주석을 상세히 달아서 보면 이해가 될겁니당!
- 람다

  - node로 작성했습니다
  - columndefault로 0이 들어가기 때문에 0인 데이터들을 제외했습니당
  - 트리거로 매일 자정에 작동하도록 했습니다

```javascript
const setRankQuery = `SET @rank := 0`;

const updateRankingQuery = `
            UPDATE user u
            JOIN (
                SELECT id, (@rank := @rank + 1) AS ranking
                FROM user
                WHERE cumulative_point > 0
                ORDER BY cumulative_point DESC ) ranked
                ON u.id = ranked.id
                SET u.ranking = ranked.ranking;
        `;
```


closed #9