### PR TITLE
feat : 제보,에러 횟수 조회 (어드민 페이지)

### DIFF
--- a/src/main/java/com/example/nzgeneration/domain/retool/RetoolController.java
+++ b/src/main/java/com/example/nzgeneration/domain/retool/RetoolController.java
@@ -1,0 +1,24 @@
+package com.example.nzgeneration.domain.retool;
+
+import com.example.nzgeneration.domain.retool.dto.GetReportCountResponse;
+import com.example.nzgeneration.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "리툴" ,description = "어드민 페이지 API")
+@RequestMapping("/api/retool")
+public class RetoolController {
+
+    private final RetoolService retoolService;
+
+    @GetMapping("/report/count")
+    public ApiResponse<GetReportCountResponse> findReportCountResponse() {
+        return ApiResponse.onSuccess(retoolService.findReportCount());
+    }
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/retool/RetoolService.java
+++ b/src/main/java/com/example/nzgeneration/domain/retool/RetoolService.java
@@ -1,0 +1,46 @@
+package com.example.nzgeneration.domain.retool;
+
+import com.example.nzgeneration.domain.retool.dto.GetReportCountResponse;
+import com.example.nzgeneration.domain.trashcanerrorreport.TrashcanErrorReportService;
+import com.example.nzgeneration.domain.trashcanreport.TrashcanReportService;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RetoolService {
+
+
+    private final TrashcanReportService trashcanReportService;
+    private final TrashcanErrorReportService trashcanErrorReportService;
+
+    public GetReportCountResponse findReportCount() {
+        int reportCount = trashcanReportService.findCountReport();
+        int errorCount = trashcanErrorReportService.findCountError();
+
+        List<Integer> reportCountList = trashcanReportService.findReportCountList();
+        List<Integer> errorCountList = trashcanErrorReportService.findErrorCountList();
+
+        //최근 6달 리스트
+        List<String> month =  new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        LocalDate currentDate = LocalDate.now();
+        for(int i = 0; i < 6; i++) {
+            month.add(currentDate.format(formatter));
+            currentDate = currentDate.minusMonths(1);
+        }
+
+
+        return GetReportCountResponse.builder()
+            .reportCount(reportCount)
+            .errorCount(errorCount)
+            .reportCountList(reportCountList)
+            .errorCountList(errorCountList)
+            .month(month)
+            .build();
+    }
+}

--- a/src/main/java/com/example/nzgeneration/domain/retool/dto/GetReportCountResponse.java
+++ b/src/main/java/com/example/nzgeneration/domain/retool/dto/GetReportCountResponse.java
@@ -1,0 +1,19 @@
+package com.example.nzgeneration.domain.retool.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class GetReportCountResponse {
+
+    private int reportCount;
+    private int errorCount;
+
+    private List<Integer> reportCountList;
+    private List<Integer> errorCountList;
+    private List<String> month;
+}

--- a/src/main/java/com/example/nzgeneration/domain/trashcanerrorreport/TrashcanErrorReport.java
+++ b/src/main/java/com/example/nzgeneration/domain/trashcanerrorreport/TrashcanErrorReport.java
@@ -2,6 +2,7 @@ package com.example.nzgeneration.domain.trashcanerrorreport;
 
 import com.example.nzgeneration.domain.trashcan.Trashcan;
 import com.example.nzgeneration.domain.user.User;
+import com.example.nzgeneration.global.utils.BaseTimeEntity;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -19,7 +20,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-public class TrashcanErrorReport {
+public class TrashcanErrorReport extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/nzgeneration/domain/trashcanerrorreport/TrashcanErrorReportRepository.java
+++ b/src/main/java/com/example/nzgeneration/domain/trashcanerrorreport/TrashcanErrorReportRepository.java
@@ -2,9 +2,19 @@ package com.example.nzgeneration.domain.trashcanerrorreport;
 
 import com.example.nzgeneration.domain.trashcanreport.TrashcanReport;
 import com.example.nzgeneration.domain.user.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TrashcanErrorReportRepository extends JpaRepository<TrashcanErrorReport, Long> {
     List<TrashcanErrorReport> findByUser(User user);
+
+    @Query("SELECT COUNT(e) FROM TrashcanErrorReport e")
+    int countAllErrors();
+
+    @Query("SELECT COUNT(e) FROM TrashcanErrorReport e WHERE e.createdAt BETWEEN :startDate AND :endDate")
+    int countErrorReportsBetween(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/example/nzgeneration/domain/trashcanerrorreport/TrashcanErrorReportService.java
+++ b/src/main/java/com/example/nzgeneration/domain/trashcanerrorreport/TrashcanErrorReportService.java
@@ -5,6 +5,12 @@ import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.domain.user.UserRepository;
 import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,4 +40,26 @@ public class TrashcanErrorReportService {
         trashcanErrorReportRepository.save(trashcanErrorReport);
         return "오류 제보 성공";
     }
+
+    public int findCountError() {
+        return trashcanErrorReportRepository.countAllErrors();
+    }
+
+    public List<Integer> findErrorCountList() {
+        List<Integer> errorCountList = new ArrayList<>();
+        LocalDate currentDate = LocalDate.now();
+
+        for (int i = 0; i < 6; i++) {
+            YearMonth yearMonth = YearMonth.from(currentDate.minusMonths(i));
+            LocalDate startDate = yearMonth.atDay(1);
+            LocalDate endDate = yearMonth.atEndOfMonth();
+            LocalDateTime startDateTime = startDate.atStartOfDay();
+            LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
+            int count = trashcanErrorReportRepository.countErrorReportsBetween(startDateTime, endDateTime);
+            errorCountList.add(count);
+        }
+
+        return errorCountList;
+    }
+
 }

--- a/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportRepository.java
+++ b/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportRepository.java
@@ -1,9 +1,19 @@
 package com.example.nzgeneration.domain.trashcanreport;
 
 import com.example.nzgeneration.domain.user.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TrashcanReportRepository extends JpaRepository<TrashcanReport, Long> {
     List<TrashcanReport> findByTrashcanReportUser(User user);
+
+    @Query("select count(r) FROM TrashcanReport r")
+    int countAllReports();
+
+    @Query("SELECT COUNT(r) FROM TrashcanReport r WHERE r.createdAt BETWEEN :startDate AND :endDate")
+    int countReportsBetween(@Param("startDate") LocalDateTime startDateTime, @Param("endDate") LocalDateTime endDateTime);
 }

--- a/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportService.java
+++ b/src/main/java/com/example/nzgeneration/domain/trashcanreport/TrashcanReportService.java
@@ -5,6 +5,12 @@ import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.domain.user.UserRepository;
 import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,4 +37,26 @@ public class TrashcanReportService {
 
         trashcanReportRepository.save(trashcanReport);
     }
+
+    public int findCountReport() {
+        return trashcanReportRepository.countAllReports();
+    }
+
+    public List<Integer> findReportCountList() {
+        List<Integer> reportCountList = new ArrayList<>();
+        LocalDate currentDate = LocalDate.now();
+
+        for (int i = 0; i < 6; i++) {
+            YearMonth yearMonth = YearMonth.from(currentDate.minusMonths(i));
+            LocalDate startDate = yearMonth.atDay(1);
+            LocalDate endDate = yearMonth.atEndOfMonth();
+            LocalDateTime startDateTime = startDate.atStartOfDay();
+            LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
+            int count = trashcanReportRepository.countReportsBetween(startDateTime, endDateTime);
+            reportCountList.add(count);
+        }
+
+        return reportCountList;
+    }
+
 }


### PR DESCRIPTION
## 요약

- 어드민 페이지 api중 하나를 작성했습니다 연결 잘되면 나머지는 한번에 pr올릴게욥

## 상세 내용

<img width="941" alt="image" src="https://github.com/NZ-generation/WhereRU-server/assets/117848386/417630a6-85e2-49ce-9eab-6edc58fd6ae2">

- 여기에 쓸 api입니닷
- 위 개수는 전체 개수
- 아래는 최근 6개월로 조회합니다

- 크게 에러개수 조회, 제보 개수 조회, 6개월간 에러개수 조회, 6개월간 제보개수 조회, 6개월간 달 리스트 로 나뉩니다


- 최근 6개월간 달마다의 개수 구하기
```java

for (int i = 0; i < 6; i++) {
            YearMonth yearMonth = YearMonth.from(currentDate.minusMonths(i));
            LocalDate startDate = yearMonth.atDay(1);
            LocalDate endDate = yearMonth.atEndOfMonth();
            LocalDateTime startDateTime = startDate.atStartOfDay();
            LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
            int count = trashcanReportRepository.countReportsBetween(startDateTime, endDateTime);
            reportCountList.add(count);
        }

```

- YearMonth : 현재날짜로부터 i(한달씩) 뺀 연도와 달 객체 생성
- startDate, endDate : 해당 YearMonth(ex. 5/27) 의 첫번째 날과 마지막 날을 구함(ex. 5/1 ~ 5/31)
- LocalDateTime으로 바꾸는 이유 : jpa쿼리메소드에 Datetime을 넣어줬더니 알아서 변환이 안돼요ㅠ createdAt이랑 비교안됨!

## 테스트 확인 내용

![image](https://github.com/NZ-generation/WhereRU-server/assets/117848386/353bcbef-aaa7-4070-bf65-5282617aa703)


## 질문 및 이외 사항

- ex) 이 부분에서 쿼리가 너무 많이 날라가는 것 같은데 좋은 방법 있을까요?
