### PR TITLE
feat: 애플 로그인 인자 수정(idToken -> code), 애플 탈퇴 구현

### DIFF
--- a/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
@@ -1,8 +1,11 @@
 package com.example.nzgeneration.domain.auth;
 
+import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.TokenRevokeRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCPublicKeysResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 
 @FeignClient(name = "AppleOAuthClient", url = "https://appleid.apple.com")
@@ -10,6 +13,12 @@ public interface AppleAuthApiClient {
 
     @GetMapping("/auth/keys")
     OIDCPublicKeysResponse getAppleOIDCOpenKeys();
+
+    @PostMapping("/auth/revoke")
+    void revokeAppleRefreshToken(@RequestBody TokenRevokeRequest tokenRevokeRequest);
+
+
+
 
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
@@ -1,12 +1,13 @@
 package com.example.nzgeneration.domain.auth;
 
-import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.GenerateTokenRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.TokenRevokeRequest;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.AppleTokenResponse;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCPublicKeysResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 
 @FeignClient(name = "AppleOAuthClient", url = "https://appleid.apple.com")
@@ -19,10 +20,9 @@ public interface AppleAuthApiClient {
     void revokeAppleRefreshToken(@RequestBody TokenRevokeRequest tokenRevokeRequest);
 
     @PostMapping("/auth/token")
-    void generateToken(@RequestBody GenerateTokenRequest generateTokenRequest);
-
-
-
-
+    AppleTokenResponse generateToken(@RequestParam("client_id") String clientId,
+        @RequestParam("client_secret") String clientSecret,
+        @RequestParam("code") String code,
+        @RequestParam("grant_type") String grantType);
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
@@ -17,7 +17,7 @@ public interface AppleAuthApiClient {
     OIDCPublicKeysResponse getAppleOIDCOpenKeys();
 
     @PostMapping("/auth/revoke")
-    void revokeAppleRefreshToken(@RequestBody TokenRevokeRequest tokenRevokeRequest);
+    void revokeAppleRefreshToken(@RequestParam("client_id") String clientId, @RequestParam("client_secret") String clientSecret, @RequestParam("token") String token, @RequestParam("token_type_hint") String token_type_hint);
 
     @PostMapping("/auth/token")
     AppleTokenResponse generateToken(@RequestParam("client_id") String clientId,

--- a/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AppleAuthApiClient.java
@@ -1,5 +1,6 @@
 package com.example.nzgeneration.domain.auth;
 
+import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.GenerateTokenRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.TokenRevokeRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCPublicKeysResponse;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -16,6 +17,9 @@ public interface AppleAuthApiClient {
 
     @PostMapping("/auth/revoke")
     void revokeAppleRefreshToken(@RequestBody TokenRevokeRequest tokenRevokeRequest);
+
+    @PostMapping("/auth/token")
+    void generateToken(@RequestBody GenerateTokenRequest generateTokenRequest);
 
 
 

--- a/src/main/java/com/example/nzgeneration/domain/auth/AppleOauthHelper.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AppleOauthHelper.java
@@ -1,10 +1,9 @@
 package com.example.nzgeneration.domain.auth;
 
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.TokenRevokeRequest;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.AppleTokenResponse;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCPublicKeysResponse;
 import com.example.nzgeneration.global.security.JwtOIDCProvider;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -33,10 +32,14 @@ public class AppleOauthHelper {
         );
     }
 
-    public void revokeToken(String token){
+    public void revokeToken(String token) throws Exception {
         TokenRevokeRequest tokenRevokeRequest = new TokenRevokeRequest(clientId,
             jwtOIDCProvider.createSecretKey(),token, "refresh_token");
         appleAuthApiClient.revokeAppleRefreshToken(tokenRevokeRequest);
+    }
+
+    public AppleTokenResponse getTokenRequest(String code) throws Exception {
+        return appleAuthApiClient.generateToken(clientId, jwtOIDCProvider.createSecretKey(), code, "authorization_code");
     }
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AppleOauthHelper.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AppleOauthHelper.java
@@ -1,6 +1,10 @@
 package com.example.nzgeneration.domain.auth;
 
+import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.TokenRevokeRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCPublicKeysResponse;
+import com.example.nzgeneration.global.security.JwtOIDCProvider;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -11,6 +15,7 @@ import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCDecodePayloa
 public class AppleOauthHelper {
     private final AppleAuthApiClient appleAuthApiClient;
     private final OauthOIDCHelper oauthOIDCHelper;
+    private final JwtOIDCProvider jwtOIDCProvider;
 
     @Value("${social-login.provider.apple.client-id}")
     private String aud;
@@ -18,11 +23,20 @@ public class AppleOauthHelper {
     @Value("${social-login.provider.apple.issuer}")
     private String iss;
 
+    @Value("${social-login.provider.apple.client-id}")
+    private String clientId;
+
     public OIDCDecodePayload getOIDCDecodePayload(String token){
         OIDCPublicKeysResponse oidcPublicKeysResponse = appleAuthApiClient.getAppleOIDCOpenKeys();
         return oauthOIDCHelper.getPayloadFromIdToken(
             token, iss, aud, oidcPublicKeysResponse
         );
+    }
+
+    public void revokeToken(String token){
+        TokenRevokeRequest tokenRevokeRequest = new TokenRevokeRequest(clientId,
+            jwtOIDCProvider.createSecretKey(),token, "refresh_token");
+        appleAuthApiClient.revokeAppleRefreshToken(tokenRevokeRequest);
     }
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AppleOauthHelper.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AppleOauthHelper.java
@@ -33,9 +33,7 @@ public class AppleOauthHelper {
     }
 
     public void revokeToken(String token) throws Exception {
-        TokenRevokeRequest tokenRevokeRequest = new TokenRevokeRequest(clientId,
-            jwtOIDCProvider.createSecretKey(),token, "refresh_token");
-        appleAuthApiClient.revokeAppleRefreshToken(tokenRevokeRequest);
+        appleAuthApiClient.revokeAppleRefreshToken(clientId, jwtOIDCProvider.createSecretKey(), token, "refresh_token");
     }
 
     public AppleTokenResponse getTokenRequest(String code) throws Exception {

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
@@ -58,7 +58,7 @@ public class AuthController {
 
     @PostMapping("/delete-account")
     @Operation(summary = "유저 탈퇴")
-    public ApiResponse<String> deleteAcccount(@CurrentUser User user) throws Exception {
+    public ApiResponse<String> deleteAccount(@CurrentUser User user) throws Exception {
         authService.deleteAccount(user);
         return ApiResponse.onSuccess("탈퇴 완료되었습니다.");
     }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
@@ -60,8 +60,8 @@ public class AuthController {
         authService.deleteAccount(user);
         return ApiResponse.onSuccess("탈퇴 완료되었습니다.");
     }
-    @GetMapping("/secret-key")
-    public String getSecretKey(){
-        return authService.getSecretKey();
-    }
+//    @GetMapping("/secret-key")
+//    public String getSecretKey(){
+//        return authService.getSecretKey();
+//    }
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
@@ -1,7 +1,6 @@
 package com.example.nzgeneration.domain.auth;
 
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
-import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.UserIdTokenRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.LoginSimpleInfo;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.TokenRefreshSimpleInfo;
 import com.example.nzgeneration.domain.user.User;
@@ -26,15 +25,15 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/login")
-    @Operation(summary = "로그인/회원가입 api", description = "code : Authorization code / 회원가입, 로그인 구분 없이 동일한 API 사용")
-    public ApiResponse<LoginSimpleInfo> login(@RequestBody UserIdTokenRequest userTokenRequest){
-        LoginSimpleInfo loginSimpleInfo = authService.login(userTokenRequest.getIdToken());
-        if(loginSimpleInfo.getIsSignUp()){
-            return ApiResponse.onSuccess(loginSimpleInfo);
-        }
-        return ApiResponse.onFailure(4003, "추가 정보 입력이 필요합니다", loginSimpleInfo);
-    }
+//    @PostMapping("/login")
+//    @Operation(summary = "로그인/회원가입 api", description = "code : Authorization code / 회원가입, 로그인 구분 없이 동일한 API 사용")
+//    public ApiResponse<LoginSimpleInfo> login(@RequestBody UserIdTokenRequest userTokenRequest){
+//        LoginSimpleInfo loginSimpleInfo = authService.login(userTokenRequest.getAuthCode());
+//        if(loginSimpleInfo.getIsSignUp()){
+//            return ApiResponse.onSuccess(loginSimpleInfo);
+//        }
+//        return ApiResponse.onFailure(4003, "추가 정보 입력이 필요합니다", loginSimpleInfo);
+//    }
 
     @PostMapping("/signup/extra")
     @Operation(summary = "회원가입 추가 정보 입력 api")
@@ -60,5 +59,9 @@ public class AuthController {
     public ApiResponse<String> deleteAcccount(@CurrentUser User user){
         authService.deleteAccount(user);
         return ApiResponse.onSuccess("탈퇴 완료되었습니다.");
+    }
+    @GetMapping("/secret-key")
+    public String getSecretKey(){
+        return authService.getSecretKey();
     }
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.nzgeneration.domain.auth;
 
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
+import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.UserIdTokenRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.LoginSimpleInfo;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.TokenRefreshSimpleInfo;
 import com.example.nzgeneration.domain.user.User;
@@ -25,15 +26,16 @@ public class AuthController {
 
     private final AuthService authService;
 
-//    @PostMapping("/login")
-//    @Operation(summary = "로그인/회원가입 api", description = "code : Authorization code / 회원가입, 로그인 구분 없이 동일한 API 사용")
-//    public ApiResponse<LoginSimpleInfo> login(@RequestBody UserIdTokenRequest userTokenRequest){
-//        LoginSimpleInfo loginSimpleInfo = authService.login(userTokenRequest.getAuthCode());
-//        if(loginSimpleInfo.getIsSignUp()){
-//            return ApiResponse.onSuccess(loginSimpleInfo);
-//        }
-//        return ApiResponse.onFailure(4003, "추가 정보 입력이 필요합니다", loginSimpleInfo);
-//    }
+    @PostMapping("/login")
+    @Operation(summary = "로그인/회원가입 api", description = "code : Authorization code / 회원가입, 로그인 구분 없이 동일한 API 사용")
+    public ApiResponse<LoginSimpleInfo> login(@RequestBody UserIdTokenRequest userTokenRequest)
+        throws Exception {
+        LoginSimpleInfo loginSimpleInfo = authService.login(userTokenRequest.getAuthCode());
+        if(loginSimpleInfo.getIsSignUp()){
+            return ApiResponse.onSuccess(loginSimpleInfo);
+        }
+        return ApiResponse.onFailure(4003, "추가 정보 입력이 필요합니다", loginSimpleInfo);
+    }
 
     @PostMapping("/signup/extra")
     @Operation(summary = "회원가입 추가 정보 입력 api")
@@ -56,12 +58,8 @@ public class AuthController {
 
     @PostMapping("/delete-account")
     @Operation(summary = "유저 탈퇴")
-    public ApiResponse<String> deleteAcccount(@CurrentUser User user){
+    public ApiResponse<String> deleteAcccount(@CurrentUser User user) throws Exception {
         authService.deleteAccount(user);
         return ApiResponse.onSuccess("탈퇴 완료되었습니다.");
     }
-//    @GetMapping("/secret-key")
-//    public String getSecretKey(){
-//        return authService.getSecretKey();
-//    }
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthController.java
@@ -4,7 +4,9 @@ import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.UserIdTokenRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.LoginSimpleInfo;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.TokenRefreshSimpleInfo;
+import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.global.common.response.ApiResponse;
+import com.example.nzgeneration.global.security.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -51,5 +53,12 @@ public class AuthController {
     public ApiResponse<Boolean> checkNickName(@PathVariable String nickname){
         boolean status = authService.checkNickNameDuplicate(nickname);
         return ApiResponse.onSuccess(status);
+    }
+
+    @PostMapping("/delete-account")
+    @Operation(summary = "유저 탈퇴")
+    public ApiResponse<String> deleteAcccount(@CurrentUser User user){
+        authService.deleteAccount(user);
+        return ApiResponse.onSuccess("탈퇴 완료되었습니다.");
     }
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
@@ -82,7 +82,7 @@ public class AuthService {
         userService.deleteUserWithName(user.getNickname());
     }
 
-    public String getSecretKey(){
-        return jwtOIDCProvider.createSecretKey();
-    }
+//    public String getSecretKey() {
+//        return jwtOIDCProvider.createSecretKey();
+//    }
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
@@ -1,11 +1,13 @@
 package com.example.nzgeneration.domain.auth;
 
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
+import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.TokenRevokeRequest;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.LoginSimpleInfo;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCDecodePayload;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.TokenRefreshSimpleInfo;
 import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.domain.user.UserRepository;
+import com.example.nzgeneration.domain.user.UserService;
 import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
 import com.example.nzgeneration.global.security.JwtTokenProvider;
@@ -21,6 +23,8 @@ public class AuthService {
     private final AppleOauthHelper appleOauthHelper;
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserService userService;
+
     @Transactional
     public LoginSimpleInfo login(String idToken){
         OIDCDecodePayload oidcDecodePayload = appleOauthHelper.getOIDCDecodePayload(idToken);
@@ -72,5 +76,10 @@ public class AuthService {
             return false;
         }
         return true;
+    }
+
+    public void deleteAccount(User user){
+        appleOauthHelper.revokeToken(user.getAppleRefreshToken());
+        userService.deleteUserWithName(user.getNickname());
     }
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
@@ -1,15 +1,19 @@
 package com.example.nzgeneration.domain.auth;
 
 import com.example.nzgeneration.domain.auth.dto.AuthRequestDto.CreateUserRequest;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.AppleTokenResponse;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.LoginSimpleInfo;
+import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.OIDCDecodePayload;
 import com.example.nzgeneration.domain.auth.dto.AuthResponseDto.TokenRefreshSimpleInfo;
 import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.domain.user.UserRepository;
 import com.example.nzgeneration.domain.user.UserService;
 import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
-import com.example.nzgeneration.global.security.JwtOIDCProvider;
 import com.example.nzgeneration.global.security.JwtTokenProvider;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,36 +26,54 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserService userService;
-    private final JwtOIDCProvider jwtOIDCProvider;
 
-//    @Transactional
-//    public LoginSimpleInfo login(String code){
-//        OIDCDecodePayload oidcDecodePayload = appleOauthHelper.getOIDCDecodePayload(idToken);
-//        String email = oidcDecodePayload.email();
-//        Optional<User> optionalMember = userRepository.findByEmail(email);
-//        String accessToken, refreshToken;
-//        if(optionalMember.isPresent()){ //로그인 로직
-//            accessToken = jwtTokenProvider.createAccessToken(optionalMember.get().getPayload());
-//            refreshToken = jwtTokenProvider.createRefreshToken(optionalMember.get().getId());
-//            optionalMember.get().updateToken(accessToken, refreshToken);
-//            return LoginSimpleInfo.toDTO(accessToken, refreshToken, true);
-//        }
-//        accessToken = jwtTokenProvider.generateTempToken(email);
-//        return LoginSimpleInfo.toDTO(accessToken, null, false);
-//
-//    }
+    @Transactional
+    public LoginSimpleInfo login(String code) throws Exception {
+        AppleTokenResponse appleTokenResponse = appleOauthHelper.getTokenRequest(code);
+        String idToken = appleTokenResponse.id_token();
+        OIDCDecodePayload oidcDecodePayload = appleOauthHelper.getOIDCDecodePayload(idToken);
+        String email = oidcDecodePayload.email();
+        String appleRefreshToken = appleTokenResponse.refresh_token();
+        String payload = email+"+"+appleRefreshToken;
+        Optional<User> optionalMember = userRepository.findByEmail(email);
+        String accessToken, refreshToken;
+        if(optionalMember.isPresent()){ //로그인 로직
+            accessToken = jwtTokenProvider.createAccessToken(optionalMember.get().getPayload());
+            refreshToken = jwtTokenProvider.createRefreshToken(optionalMember.get().getId());
+            optionalMember.get().updateToken(accessToken, refreshToken);
+            return LoginSimpleInfo.toDTO(accessToken, refreshToken, true);
+        }
+        accessToken = jwtTokenProvider.generateTempToken(payload);
+        return LoginSimpleInfo.toDTO(accessToken, null, false);
+    }
 
     @Transactional
     public LoginSimpleInfo signUp(CreateUserRequest createUserRequest){
-        String email = jwtTokenProvider.validateTempTokenAndGetEmail(createUserRequest.getToken());
+        String payload = jwtTokenProvider.validateTempTokenAndGetPayload(createUserRequest.getToken());
+        Map<String, String> userInfo = getUserInfoInPayload(payload);
+        String email = userInfo.get("email");
+        String appleRefreshToken = userInfo.get("appleRefreshToken");
         if(userRepository.findByEmail(email).isPresent())
             throw new GeneralException(ErrorStatus._DUPLICATE_USER);
         User user = User.toEntity(email, createUserRequest);
         userRepository.save(user);
         String accessToken = jwtTokenProvider.createAccessToken(user.getPayload());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
-        user.updateToken(accessToken, refreshToken);
+        user.signUpToken(accessToken, refreshToken, appleRefreshToken);
         return LoginSimpleInfo.toDTO(accessToken, refreshToken, true);
+    }
+
+    public Map<String, String> getUserInfoInPayload (String payload){
+        String[] parts = payload.split("\\+");
+        Map<String, String> map = new HashMap<>();
+
+        String email = parts[0];
+        String appleRefreshToken = parts[1];
+
+        map.put("email", email);
+        map.put("appleRefreshToken", appleRefreshToken);
+
+        return map;
     }
 
     @Transactional
@@ -77,12 +99,12 @@ public class AuthService {
         return true;
     }
 
-    public void deleteAccount(User user){
+    public void deleteAccount(User user) throws Exception {
         appleOauthHelper.revokeToken(user.getAppleRefreshToken());
         userService.deleteUserWithName(user.getNickname());
     }
 
-//    public String getSecretKey() {
+//    public String getSecretKey() throws Exception {
 //        return jwtOIDCProvider.createSecretKey();
 //    }
 }

--- a/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/AuthService.java
@@ -10,6 +10,7 @@ import com.example.nzgeneration.domain.user.UserRepository;
 import com.example.nzgeneration.domain.user.UserService;
 import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
+import com.example.nzgeneration.global.security.JwtOIDCProvider;
 import com.example.nzgeneration.global.security.JwtTokenProvider;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,6 +46,7 @@ public class AuthService {
         }
         accessToken = jwtTokenProvider.generateTempToken(payload);
         return LoginSimpleInfo.toDTO(accessToken, null, false);
+
     }
 
     @Transactional

--- a/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
@@ -3,6 +3,7 @@ package com.example.nzgeneration.domain.auth.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 public class AuthRequestDto {
 
@@ -24,6 +25,17 @@ public class AuthRequestDto {
     @AllArgsConstructor
     public static class UserIdTokenRequest{
         private String idToken;
+
+    }
+
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenRevokeRequest{
+        private String client_id;
+        private String client_secret;
+        private String token;
+        private String token_type_hint;
 
     }
 

--- a/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
@@ -12,7 +12,6 @@ public class AuthRequestDto {
     @AllArgsConstructor
     public static class CreateUserRequest {
         private String token;
-        private String appleRefreshToken;
         private String nickName;
         private String walletAddress;
         private Boolean isAllowLocationInfo;
@@ -39,13 +38,6 @@ public class AuthRequestDto {
 
     }
 
-    public static class GenerateTokenRequest{
-        private String client_id;
-        private String client_secret;
-        private String code;
-        private String grant_type;
-
-    }
 
 
 

--- a/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthRequestDto.java
@@ -24,7 +24,7 @@ public class AuthRequestDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserIdTokenRequest{
-        private String idToken;
+        private String authCode;
 
     }
 
@@ -36,6 +36,14 @@ public class AuthRequestDto {
         private String client_secret;
         private String token;
         private String token_type_hint;
+
+    }
+
+    public static class GenerateTokenRequest{
+        private String client_id;
+        private String client_secret;
+        private String code;
+        private String grant_type;
 
     }
 

--- a/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/auth/dto/AuthResponseDto.java
@@ -70,6 +70,11 @@ public class AuthResponseDto {
     ){
     }
 
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record AppleTokenResponse(
+        String access_token, String token_type, String expires_in, String refresh_token, String id_token
+    ){}
+
 
 
 

--- a/src/main/java/com/example/nzgeneration/domain/user/User.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/User.java
@@ -68,6 +68,12 @@ public class User extends BaseTimeEntity {
         this.refreshToken = refreshToken;
     }
 
+    public void signUpToken(String accessToken, String refreshToken, String appleRefreshToken){
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.appleRefreshToken = appleRefreshToken;
+    }
+
     public void updateNickName(String nickname){
         this.nickname = nickname;
     }
@@ -98,7 +104,6 @@ public class User extends BaseTimeEntity {
             .walletAddress(createUserRequest.getWalletAddress())
             .isAllowAdNotification(createUserRequest.getIsAllowAdInfo())
             .isAllowLocationInfo(createUserRequest.getIsAllowLocationInfo())
-            .appleRefreshToken(createUserRequest.getAppleRefreshToken())
             .badgeCount(0)
             .cumulativePoint(0)
             .currentPoint(0)

--- a/src/main/java/com/example/nzgeneration/domain/user/UserService.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserService.java
@@ -96,7 +96,6 @@ public class UserService {
     public void deleteUserWithName(String userName){
         User user = userRepository.findByNickname(userName)
             .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
-
         List<TrashcanReport> reportList = trashcanReportRepository.findByTrashcanReportUser(user);
         List<TrashcanErrorReport> errorReportList = trashcanErrorReportRepository.findByUser(user);
         List<Nft> nftList = nftRepository.findByUser(user);

--- a/src/main/java/com/example/nzgeneration/domain/user/UserService.java
+++ b/src/main/java/com/example/nzgeneration/domain/user/UserService.java
@@ -10,7 +10,6 @@ import com.example.nzgeneration.domain.trashcanerrorreport.TrashcanErrorReport;
 import com.example.nzgeneration.domain.trashcanerrorreport.TrashcanErrorReportRepository;
 import com.example.nzgeneration.domain.trashcanreport.TrashcanReport;
 import com.example.nzgeneration.domain.trashcanreport.TrashcanReportRepository;
-import com.example.nzgeneration.domain.user.dto.UserResponseDto.BadgeInfo;
 import com.example.nzgeneration.domain.user.dto.UserResponseDto.PatchProfileImg;
 import com.example.nzgeneration.domain.user.dto.UserResponseDto.RankingInfo;
 import com.example.nzgeneration.domain.user.dto.UserResponseDto.UserEditingPageDetailInfo;
@@ -38,7 +37,6 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final S3Service s3Service;
-    private final AuthService authService;
     private final TrashcanReportRepository trashcanReportRepository;
     private final TrashcanErrorReportRepository trashcanErrorReportRepository;
     private final MemberBadgeRepository memberBadgeRepository;
@@ -54,10 +52,18 @@ public class UserService {
 
     @Transactional
     public void updateNickName(User user, String name) {
-        if (!authService.checkNickNameDuplicate(name)) {
+        if (checkNickNameDuplicate(name)) {
             throw new GeneralException(ErrorStatus._DUPLICATE_NICKNAME);
         }
         user.updateNickName(name);
+    }
+
+    @Transactional
+    public boolean checkNickNameDuplicate(String name){
+        if(userRepository.findByNickname(name).isPresent()){
+            return false;
+        }
+        return true;
     }
 
     @Transactional

--- a/src/main/java/com/example/nzgeneration/global/s3/S3Controller.java
+++ b/src/main/java/com/example/nzgeneration/global/s3/S3Controller.java
@@ -5,6 +5,7 @@ import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
 import com.example.nzgeneration.global.common.response.exception.GeneralException;
 import com.example.nzgeneration.global.s3.dto.S3Result;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -13,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RestController
+@Slf4j
 public class S3Controller {
     private final S3Service s3Service;
 
@@ -22,6 +24,7 @@ public class S3Controller {
             S3Result result = s3Service.uploadFile(file);
             return ResponseEntity.ok(result);
         } catch (Exception e) {
+            log.error(e.toString());
             throw new GeneralException(ErrorStatus._FILE_UPLOAD_ERROR);
         }
     }

--- a/src/main/java/com/example/nzgeneration/global/security/JwtOIDCProvider.java
+++ b/src/main/java/com/example/nzgeneration/global/security/JwtOIDCProvider.java
@@ -139,7 +139,7 @@ public class JwtOIDCProvider {
             .setExpiration(expirationDate)
             .setAudience(issuer)
             .setSubject(clientId)
-            .signWith(SignatureAlgorithm.ES256, newPrivateKey)  // Use the Key and SignatureAlgorithm as parameters
+            .signWith(SignatureAlgorithm.ES256, newPrivateKey)
             .compact();
     }
 

--- a/src/main/java/com/example/nzgeneration/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/nzgeneration/global/security/JwtTokenProvider.java
@@ -121,7 +121,7 @@ public class JwtTokenProvider {
             .compact();
     }
 
-    public String validateTempTokenAndGetEmail(String token) {
+    public String validateTempTokenAndGetPayload(String token) {
         try {
             return Jwts.parser()
                 .setSigningKey(getSecretKey())


### PR DESCRIPTION
## 요약
-애플 로그인 인자 수정과 애플 탈퇴를 구현했습니다

## 상세 내용
- 애플 로그인 인자를 수정했습니담 : 기존 idToken에서 사용자 정보를 바로 빼왔는데, 탈퇴를 구현하면서 논리의 비약을 느꼈기 때문 .. 탈퇴 구현 시 appleRefreshToken이 필요한데, 이는 authorization code에서 api를 한번 더 호출해야 구할 수 있습니담
- 근데 해당 api에 client_secret이라는 직접 만든 Jwt 토큰이 필요한데, 이를 프론트에 전달해서 프론트에서 api를 호출해서 백엔드로 전해주는 것 보다는 그냥 백엔드에서 code를 받아서 token을 구해오는 과정이 더 합리적일 것 같아서 바꿨습니다
- 탈퇴 api도 구현했습니다 . 별거 없구 회원가입할 때 code로 appleRefreshToken을 구하고 DB에 저장 해놓는데, 이를 넣고 토큰 무효화 api를 쏘면 됩니다. 저번에 iOS에서 요청한 유저 이름으로 유저 삭제 api에서 사용한 cascading 함수를 그대로 사용해서 유저를 삭제합니다. 

## 테스트 확인 내용



## 질문 및 이외 사항
