### PR TITLE
feat: Nft 관련 Api 구현

### DIFF
--- a/src/main/java/com/example/nzgeneration/domain/board/Board.java
+++ b/src/main/java/com/example/nzgeneration/domain/board/Board.java
@@ -29,4 +29,9 @@ public class Board extends BaseTimeEntity {
 
     private Long likeCount;
 
+    public static Board toEntity(){
+        return Board.builder()
+            .build();
+    }
+
 }

--- a/src/main/java/com/example/nzgeneration/domain/board/BoardController.java
+++ b/src/main/java/com/example/nzgeneration/domain/board/BoardController.java
@@ -5,6 +5,7 @@ import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.global.common.dto.PageResponseDto;
 import com.example.nzgeneration.global.common.response.ApiResponse;
 import com.example.nzgeneration.global.security.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +23,7 @@ public class BoardController {
     private final BoardService boardService;
 
     @PostMapping("/{id}")
+    @Operation(summary = "NFT 둘러보기 게시판 업로드")
     public ApiResponse<String> uploadNft(@CurrentUser User user, @PathVariable("id") Long nftId){
         boardService.uploadNft(user, nftId);
         return ApiResponse.onSuccess("업로드 완료");

--- a/src/main/java/com/example/nzgeneration/domain/board/BoardController.java
+++ b/src/main/java/com/example/nzgeneration/domain/board/BoardController.java
@@ -1,0 +1,32 @@
+package com.example.nzgeneration.domain.board;
+
+import com.example.nzgeneration.domain.board.dto.BoardResponseDto.NftBoardResponse;
+import com.example.nzgeneration.domain.user.User;
+import com.example.nzgeneration.global.common.dto.PageResponseDto;
+import com.example.nzgeneration.global.common.response.ApiResponse;
+import com.example.nzgeneration.global.security.CurrentUser;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name="Board", description = "NFT 게시판")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/board")
+public class BoardController {
+    private final BoardService boardService;
+
+    @PostMapping("/{id}")
+    public ApiResponse<String> uploadNft(@CurrentUser User user, @PathVariable("id") Long nftId){
+        boardService.uploadNft(user, nftId);
+        return ApiResponse.onSuccess("업로드 완료");
+    }
+
+
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/board/BoardService.java
+++ b/src/main/java/com/example/nzgeneration/domain/board/BoardService.java
@@ -1,0 +1,32 @@
+package com.example.nzgeneration.domain.board;
+
+import com.example.nzgeneration.domain.board.dto.BoardResponseDto.NftBoardResponse;
+import com.example.nzgeneration.domain.nft.Nft;
+import com.example.nzgeneration.domain.nft.NftRepository;
+import com.example.nzgeneration.domain.user.User;
+import com.example.nzgeneration.global.common.dto.PageResponseDto;
+import com.example.nzgeneration.global.common.response.code.status.ErrorStatus;
+import com.example.nzgeneration.global.common.response.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+    public final BoardRepository boardRepository;
+    public final NftRepository nftRepository;
+
+
+
+    @Transactional
+    public void uploadNft(User user, Long nftId){
+        Nft nft = nftRepository.findByUserAndId(user, nftId)
+            .orElseThrow(()-> new GeneralException(ErrorStatus._INVALID_NFT));
+        Board board = Board.toEntity();
+        boardRepository.save(board);
+        nft.setBoard(board);
+
+    }
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/board/dto/BoardResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.nzgeneration.domain.board.dto;
+
+import com.example.nzgeneration.domain.nft.dto.NftResponseDto.MyNftResponse;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BoardResponseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NftBoardResponse{
+        private List<String> nftImgUrl;
+
+        public static NftBoardResponse toDto(List<String> nftImgUrl){
+            return NftBoardResponse.builder()
+                .nftImgUrl(nftImgUrl)
+                .build();
+        }
+    }
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/nft/Nft.java
+++ b/src/main/java/com/example/nzgeneration/domain/nft/Nft.java
@@ -31,6 +31,7 @@ public class Nft extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
+    @Getter
     private String imageUrl;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/src/main/java/com/example/nzgeneration/domain/nft/Nft.java
+++ b/src/main/java/com/example/nzgeneration/domain/nft/Nft.java
@@ -26,6 +26,7 @@ public class Nft extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -36,5 +37,13 @@ public class Nft extends BaseTimeEntity {
 
     @OneToOne(cascade = CascadeType.ALL)
     @Getter
+    @Setter
     private Board board;
+
+    public static Nft toEntity(User user, String imageUrl){
+        return Nft.builder()
+            .user(user)
+            .imageUrl(imageUrl)
+            .build();
+    }
 }

--- a/src/main/java/com/example/nzgeneration/domain/nft/NftController.java
+++ b/src/main/java/com/example/nzgeneration/domain/nft/NftController.java
@@ -3,12 +3,17 @@ package com.example.nzgeneration.domain.nft;
 import com.example.nzgeneration.domain.nft.dto.NftResponseDto.MyNftResponse;
 import com.example.nzgeneration.domain.user.User;
 import com.example.nzgeneration.global.common.response.ApiResponse;
+import com.example.nzgeneration.global.openai.OpenAIService;
 import com.example.nzgeneration.global.security.CurrentUser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,12 +21,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/nft")
 @Tag(name="Nft", description = "Nft 관련")
 public class NftController {
-    public static NftService nftService;
+    private final NftService nftService;
+
 
     @GetMapping("/my-nft")
     @Operation(summary = "나의 Nft 조회")
-    public ApiResponse<MyNftResponse> getMyNft(@CurrentUser User user){
-        return ApiResponse.onSuccess(nftService.getMyNft(user));
+    public ApiResponse<List<MyNftResponse>> getMyNft(@CurrentUser User user){
+        return ApiResponse.onSuccess(nftService.getMyNfts(user));
+    }
+
+    @PostMapping("/")
+    @Operation(summary = "나의 Nft 생성")
+    public ApiResponse<MyNftResponse> makeNft(@CurrentUser User user,@RequestParam String gender, @RequestParam String action,
+        @RequestParam String animal) throws JsonProcessingException{
+        return ApiResponse.onSuccess(nftService.makeMyNft(user, gender, action, animal));
+
     }
 
 

--- a/src/main/java/com/example/nzgeneration/domain/nft/NftController.java
+++ b/src/main/java/com/example/nzgeneration/domain/nft/NftController.java
@@ -1,0 +1,29 @@
+package com.example.nzgeneration.domain.nft;
+
+import com.example.nzgeneration.domain.nft.dto.NftResponseDto.MyNftResponse;
+import com.example.nzgeneration.domain.user.User;
+import com.example.nzgeneration.global.common.response.ApiResponse;
+import com.example.nzgeneration.global.security.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/nft")
+@Tag(name="Nft", description = "Nft 관련")
+public class NftController {
+    public static NftService nftService;
+
+    @GetMapping("/my-nft")
+    @Operation(summary = "나의 Nft 조회")
+    public ApiResponse<MyNftResponse> getMyNft(@CurrentUser User user){
+        return ApiResponse.onSuccess(nftService.getMyNft(user));
+    }
+
+
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/nft/NftRepository.java
+++ b/src/main/java/com/example/nzgeneration/domain/nft/NftRepository.java
@@ -2,8 +2,10 @@ package com.example.nzgeneration.domain.nft;
 
 import com.example.nzgeneration.domain.user.User;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NftRepository extends JpaRepository<Nft, Long> {
     List<Nft> findByUser(User user);
+    Optional<Nft> findByUserAndId(User user, Long id);
 }

--- a/src/main/java/com/example/nzgeneration/domain/nft/NftService.java
+++ b/src/main/java/com/example/nzgeneration/domain/nft/NftService.java
@@ -1,0 +1,25 @@
+package com.example.nzgeneration.domain.nft;
+
+import com.example.nzgeneration.domain.nft.dto.NftResponseDto.MyNftResponse;
+import com.example.nzgeneration.domain.user.User;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NftService {
+
+    public final NftRepository nftRepository;
+
+    public MyNftResponse getMyNft(User user){
+        List<Nft> nftList = nftRepository.findByUser(user);
+        List<String> nftImgUrlList = new ArrayList<>();
+        for(Nft nft : nftList){
+            nftImgUrlList.add(nft.getImageUrl());
+        }
+        return MyNftResponse.toDto(nftImgUrlList);
+    }
+
+}

--- a/src/main/java/com/example/nzgeneration/domain/nft/NftService.java
+++ b/src/main/java/com/example/nzgeneration/domain/nft/NftService.java
@@ -2,24 +2,36 @@ package com.example.nzgeneration.domain.nft;
 
 import com.example.nzgeneration.domain.nft.dto.NftResponseDto.MyNftResponse;
 import com.example.nzgeneration.domain.user.User;
+import com.example.nzgeneration.global.openai.OpenAIService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class NftService {
 
-    public final NftRepository nftRepository;
+    private final NftRepository nftRepository;
+    private final OpenAIService openAIService;
 
-    public MyNftResponse getMyNft(User user){
+    public List<MyNftResponse> getMyNfts(User user) {
         List<Nft> nftList = nftRepository.findByUser(user);
-        List<String> nftImgUrlList = new ArrayList<>();
-        for(Nft nft : nftList){
-            nftImgUrlList.add(nft.getImageUrl());
-        }
-        return MyNftResponse.toDto(nftImgUrlList);
+        return nftList.stream()
+            .map(MyNftResponse::toDto)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public MyNftResponse makeMyNft(User user, String gender, String action, String animal)
+        throws JsonProcessingException {
+        String result = openAIService.createImage(openAIService.buildPrompt(gender, action, animal));
+        Nft nft = Nft.toEntity(user, result);
+        nftRepository.save(nft);
+        return MyNftResponse.toDto(nft);
     }
 
 }

--- a/src/main/java/com/example/nzgeneration/domain/nft/dto/NftResponseDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/nft/dto/NftResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.nzgeneration.domain.nft.dto;
 
+import com.example.nzgeneration.domain.nft.Nft;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,11 +14,13 @@ public class NftResponseDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class MyNftResponse{
-        private List<String> nftImgUrl;
+        private String nftUrl;
+        private Long nftId;
 
-        public static MyNftResponse toDto(List<String> nftImgUrl){
+        public static MyNftResponse toDto(Nft nft){
             return MyNftResponse.builder()
-                .nftImgUrl(nftImgUrl)
+                .nftUrl(nft.getImageUrl())
+                .nftId(nft.getId())
                 .build();
         }
     }

--- a/src/main/java/com/example/nzgeneration/domain/nft/dto/NftResponseDto.java
+++ b/src/main/java/com/example/nzgeneration/domain/nft/dto/NftResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.nzgeneration.domain.nft.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class NftResponseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MyNftResponse{
+        private List<String> nftImgUrl;
+
+        public static MyNftResponse toDto(List<String> nftImgUrl){
+            return MyNftResponse.builder()
+                .nftImgUrl(nftImgUrl)
+                .build();
+        }
+    }
+
+}

--- a/src/main/java/com/example/nzgeneration/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/nzgeneration/global/common/response/code/status/ErrorStatus.java
@@ -46,7 +46,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //제보 관련
     _EMPTY_TRASHCAN_REPORT(HttpStatus.CONFLICT, 4071, "존재하지 않는 쓰레기통 제보입니다."),
-    _DUPLICATED_TRASHCAN_REPORT(HttpStatus.CONFLICT, 4072, "이미 승인/거절이 된 제보입니다.")
+    _DUPLICATED_TRASHCAN_REPORT(HttpStatus.CONFLICT, 4072, "이미 승인/거절이 된 제보입니다."),
+
+    //NFT 관련
+    _INVALID_NFT(HttpStatus.CONFLICT, 4081, "존재하지 않는 NFT입니다.")
 
     ;
 


### PR DESCRIPTION
## 요약
- Nft 생성(유저 프롬프트 받아서), 나의 Nft 조회, Nft 게시판 업로드 를 구현하였습니다

## 상세 내용

- 큰 이슈는 없었는데, Nft 생성 시 OpenAI에서 제공하는 Url이 너무 길어서 url 컬럼의 길이를 1024로 늘려주었습니다!

## 테스트 확인 내용



## 질문 및 이외 사항


